### PR TITLE
Fix bug where the names were cleared from the list

### DIFF
--- a/src/List/ContextActions.js
+++ b/src/List/ContextActions.js
@@ -76,6 +76,7 @@ contextActions.delete
                             // Remove deleted item from the listStore
                             if (listStore.getState() && listStore.getState().list) {
                                 listStore.setState({
+                                    ...listStore.getState(),
                                     pager: listStore.getState().pager,
                                     list: listStore.getState().list
                                         .filter(modelToCheck => modelToCheck.id !== model.id),
@@ -83,7 +84,7 @@ contextActions.delete
                             }
 
                             snackActions.show({
-                                message: `${model.name} ${d2.i18n.getTranslation('was_deleted')}`,
+                                message: `${model.displayName} ${d2.i18n.getTranslation('was_deleted')}`,
                             });
 
                             // Fire the afterDeleteHook


### PR DESCRIPTION
The names would be cleared from the list after deleting an
object. The state of the list store did not retain the column
name definitions.

DHIS2-513