### PR TITLE
Updated order of "edit" mapping items

### DIFF
--- a/src/config/inlinehelp-mapping.json
+++ b/src/config/inlinehelp-mapping.json
@@ -7,17 +7,13 @@
     "/edit/categorySection/category": "/en/user/html/manage_category.html#create_category",
     "/list/categorySection": "/en/user/html/manage_category.html",
 
-    "/edit/dataElementSection/dataElement": "/en/user/html/manage_data_element.html#create_data_element",
-    "/list/dataElementSection/dataElement": "/en/user/html/manage_data_element.html",
-
-    "/edit/dataElementSection/dataElementGroup": "/en/user/html/manage_data_element.html#create_data_element_group",
-    "/list/dataElementSection/dataElementGroup": "/en/user/html/manage_data_element.html",
-
     "/edit/dataElementSection/dataElementGroupSet": "/en/user/html/manage_data_element.html#create_data_element_group_set",
-    "/list/dataElementSection/dataElementGroupSet": "/en/user/html/manage_data_element.html",
+    "/edit/dataElementSection/dataElementGroup": "/en/user/html/manage_data_element.html#create_data_element_group",
+    "/edit/dataElementSection/dataElement": "/en/user/html/manage_data_element.html#create_data_element",
+    "/list/dataElementSection": "/en/user/html/manage_data_element.html",
 
-    "/list/dataSetSection/dataSet": "/en/user/html/manage_data_set.html",
     "/edit/dataSetSection/dataSet": "/en/user/html/manage_data_set.html#create_data_set",
+    "/list/dataSetSection/dataSet": "/en/user/html/manage_data_set.html",
 
     "/edit/indicatorSection/indicatorGroupSet": "/en/user/html/manage_indicator.html#create_indicator_group_set",
     "/edit/indicatorSection/indicatorGroup": "/en/user/html/manage_indicator.html#create_indicator_group",
@@ -25,29 +21,17 @@
     "/edit/indicatorSection/indicator": "/en/user/html/manage_indicator.html#create_indicator",
     "/list/indicatorSection": "/en/user/html/manage_indicator.html",
 
-    "/edit/organisationUnitSection/organisationUnit": "/en/user/html/manage_organisation_unit.html#create_organisation_unit",
-    "/list/organisationUnitSection/organisationUnit": "/en/user/html/manage_organisation_unit.html",
-
-    "/edit/organisationUnitSection/organisationUnitGroup": "/en/user/html/manage_organisation_unit.html#create_organisation_unit_group",
-    "/list/organisationUnitSection/organisationUnitGroup": "/en/user/html/manage_organisation_unit.html",
-
     "/edit/organisationUnitSection/organisationUnitGroupSet": "/en/user/html/manage_organisation_unit.html#create_organisation_unit_group_set",
-    "/list/organisationUnitSection/organisationUnitGroupSet": "/en/user/html/manage_organisation_unit.html",
-
+    "/edit/organisationUnitSection/organisationUnitGroup": "/en/user/html/manage_organisation_unit.html#create_organisation_unit_group",
     "/edit/organisationUnitSection/organisationUnitLevel": "/en/user/html/manage_organisation_unit.html#name_organisation_unit_level",
-    "/list/organisationUnitSection/organisationUnitLevel": "/en/user/html/manage_organisation_unit.html",
-
-    "/edit/programSection/trackedEntityAttribute": "/en/user/html/manage_program_metadata.html#create_tracked_entity_attribute",
-    "/list/programSection/trackedEntityAttribute": "/en/user/html/manage_program_metadata.html",
-
+    "/edit/organisationUnitSection/organisationUnit": "/en/user/html/manage_organisation_unit.html#create_organisation_unit",
+    "/list/organisationUnitSection": "/en/user/html/manage_organisation_unit.html",
+    
     "/edit/programSection/trackedEntityAttributeGroup": "/en/user/html/manage_program_metadata.html#create_tracked_entity_attribute_group",
-    "/list/programSection/trackedEntityAttributeGroup": "/en/user/html/manage_program_metadata.html",
-
+    "/edit/programSection/trackedEntityAttribute": "/en/user/html/manage_program_metadata.html#create_tracked_entity_attribute",
     "/edit/programSection/relationshipType": "/en/user/html/manage_program_metadata.html#create_relationship_type",
-    "/list/programSection/relationshipType": "/en/user/html/manage_program_metadata.html",
-
     "/edit/programSection/trackedEntity": "/en/user/html/manage_program_metadata.html#create_tracked_entity",
-    "/list/programSection/trackedEntity": "/en/user/html/manage_program_metadata.html",
+    "/list/programSection": "/en/user/html/manage_program_metadata.html",
 
     "/edit/validationSection/validationNotificationTemplate": "/en/user/html/manage_validation_rule.html#create_validation_notification",
     "/edit/validationSection/validationRuleGroup": "/en/user/html/manage_validation_rule.html#create_validation_rule_group",


### PR DESCRIPTION
Reviewed items and updated order of "edit" mapping items. Also changed all list mappings to the more condensed format.
Could you verify that these two items will render correctly with regards to order and length of item names? 
- "edit" organisationUnitGroup
- "edit" organisationUnitLevel