### PR TITLE
Add eslint pre-commit hook that runs on changed files

### DIFF
--- a/bin/lintchangedfiles.sh
+++ b/bin/lintchangedfiles.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+CMT=`git merge-base origin/master HEAD`
+FILE_STRING=`git diff --name-only $CMT | grep \.js | grep -v \.json;`
+
+declare -a LIST=( $FILE_STRING )
+
+for f in "${LIST[@]}"
+do
+    ./node_modules/.bin/eslint $f
+done

--- a/bin/lintchangedfiles.sh
+++ b/bin/lintchangedfiles.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-CMT=`git merge-base origin/master HEAD`
-FILE_STRING=`git diff --name-only $CMT | grep \.js | grep -v \.json;`
+COMMIT=`git merge-base origin/master HEAD`
+FILE_STRING=`git diff --name-only $COMMIT | grep \.js | grep -v \.json;`
 
 declare -a LIST=( $FILE_STRING )
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "validate": "npm ls --depth 0 || yarn list",
     "manifest": "d2-manifest package.json build/manifest.webapp",
     "deploy": "npm run build && mvn clean deploy",
-    "lint": "echo Looks good.",
+    "lint": "LIST=`git diff-index --name-only HEAD | grep -f *.js | grep -v json;`; if [ $LIST ]; then eslint $LIST; fi",
     "profile": "yarn start -- --profile"
   },
   "devDependencies": {
@@ -95,6 +95,7 @@
     "sinon-chai": "^2.9.0"
   },
   "pre-commit": [
+    "lint",
     "validate",
     "test"
   ],

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "validate": "npm ls --depth 0 || yarn list",
     "manifest": "d2-manifest package.json build/manifest.webapp",
     "deploy": "npm run build && mvn clean deploy",
-    "lint": "LIST=`git diff-index --name-only HEAD | grep -f *.js | grep -v json;`; if [ $LIST ]; then eslint $LIST; fi",
+    "lint": "LIST=`git diff --name-only 'git merge-base origin/master HEAD' | grep -f *.js | grep -v json;`; if [ $LIST ]; then eslint $LIST; fi",
     "profile": "yarn start -- --profile"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "validate": "npm ls --depth 0 || yarn list",
     "manifest": "d2-manifest package.json build/manifest.webapp",
     "deploy": "npm run build && mvn clean deploy",
-    "lint": "./bin/lintchangedfiles.sh",
+    "lintchanged": "./bin/lintchangedfiles.sh",
+    "lint": "eslint ./src",
     "profile": "yarn start -- --profile"
   },
   "devDependencies": {
@@ -95,7 +96,6 @@
     "sinon-chai": "^2.9.0"
   },
   "pre-commit": [
-    "lint",
     "validate",
     "test"
   ],

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "validate": "npm ls --depth 0 || yarn list",
     "manifest": "d2-manifest package.json build/manifest.webapp",
     "deploy": "npm run build && mvn clean deploy",
-    "lint": "LIST=`git diff --name-only 'git merge-base origin/master HEAD' | grep -f *.js | grep -v json;`; if [ $LIST ]; then eslint $LIST; fi",
+    "lint": "./bin/lintchangedfiles.sh",
     "profile": "yarn start -- --profile"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "validate": "npm ls --depth 0 || yarn list",
     "manifest": "d2-manifest package.json build/manifest.webapp",
     "deploy": "npm run build && mvn clean deploy",
-    "lintchanged": "./bin/lintchangedfiles.sh",
-    "lint": "eslint ./src",
+    "lint-changed": "./bin/lintchangedfiles.sh",
+    "lint-all": "eslint ./src",
     "profile": "yarn start -- --profile"
   },
   "devDependencies": {


### PR DESCRIPTION
Add a pre-commit hook that runs eslint on all js files that were changed in the branch. This is to help gradually get the codebase into eslint compliance.