### PR TITLE
Temporary disable the parent field on OU form

### DIFF
--- a/src/config/field-config/field-order.js
+++ b/src/config/field-config/field-order.js
@@ -128,7 +128,6 @@ const fieldOrderByName = new Map([
         'organisationUnits',
     ]],
     ['organisationUnit', [
-        'parent',
         'name',
         'shortName',
         'code',


### PR DESCRIPTION
The parent field allows the parent of the ou to be changed
without having a special permissions. This is not acceptable
for DATIM.

As a workaround for changing the parent, the hierarchy operations
can be used while a solution to the issue is in progress.
Most likely some authority that will need to be given to the user
to be able to change the permission.

This is only a UI fix, the organisation units parent can still be
changed using the API.