### PR TITLE
Fix the npm coverage script, and show coverage for all files in src

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
     setupTestFrameworkScriptFile: '<rootDir>/config/setup.js',
+    collectCoverageFrom: ['src/**/*.js'],
     testPathIgnorePatterns: [
         '/node_modules/',
         '<rootDir>/lib/',

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "scripts": {
     "prestart": "d2-manifest package.json manifest.webapp",
     "start": "webpack-dev-server",
-    "coverage": "NODE_ENV=test nyc --include src --exclude 'src/**/*.spec.js' --require babel-register --require babel-polyfill --require ignore-styles mocha --reporter dot --require config/setup.js --recursive 'src/**/*.spec.js'",
-    "postcoverage": " nyc report --reporter=lcov",
+    "coverage": "npm test -- --coverage",
     "test": "jest",
     "test:watch": "yarn test -- --watch",
     "prebuild": "yarn test",


### PR DESCRIPTION
Coverage script was broken after switch to jest. And running coverage should show test coverage for all files, not just those with .spec files.