### PR TITLE
List data elements in program notification templates

### DIFF
--- a/src/EditModel/event-program/notifications/EventProgramNotifications.js
+++ b/src/EditModel/event-program/notifications/EventProgramNotifications.js
@@ -1,21 +1,24 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { __, first, get } from 'lodash/fp';
 import withState from 'recompose/withState';
 import compose from 'recompose/compose';
 import withHandlers from 'recompose/withHandlers';
+import mapPropsStream from 'recompose/mapPropsStream';
+
 import NotificationList from './NotificationList';
-import { getStageNotifications } from './selectors';
+import { getStageNotifications, getProgramStageDataElements } from './selectors';
 import EventProgramStageNotificationDeleteDialog from './EventProgramStageNotificationDeleteDialog';
 import { removeStageNotification, setEditModel, setAddModel } from './actions';
 import NotificationDialog from './NotificationDialog';
-import mapPropsStream from 'recompose/mapPropsStream';
 import eventProgramStore from '../eventProgramStore';
-import { __, first, get } from 'lodash/fp';
 
 const notifications$ = eventProgramStore.map(getStageNotifications);
+const programStageDataElements$ = eventProgramStore.map(getProgramStageDataElements);
 
-function EventProgramNotifications({ notifications, askForConfirmation, onCancel, onDelete, open, setOpen, modelToDelete, setEditModel, setAddModel }) {
+function EventProgramNotifications({ notifications, askForConfirmation, onCancel, onDelete, open, setOpen,
+                                     modelToDelete, setEditModel, setAddModel, dataElements }) {
     return (
         <div>
             <NotificationList
@@ -24,7 +27,7 @@ function EventProgramNotifications({ notifications, askForConfirmation, onCancel
                 onEditNotification={setEditModel}
                 onAddNotification={setAddModel}
             />
-            <NotificationDialog />
+            <NotificationDialog dataElements={dataElements} />
             <EventProgramStageNotificationDeleteDialog
                 setOpen={setOpen}
                 open={open}
@@ -35,6 +38,18 @@ function EventProgramNotifications({ notifications, askForConfirmation, onCancel
         </div>
     );
 }
+EventProgramNotifications.propTypes = {
+    notifications: PropTypes.any.isRequired,
+    askForConfirmation: PropTypes.any.isRequired,
+    onCancel: PropTypes.any.isRequired,
+    onDelete: PropTypes.any.isRequired,
+    open: PropTypes.any.isRequired,
+    setOpen: PropTypes.any.isRequired,
+    modelToDelete: PropTypes.any,
+    setEditModel: PropTypes.any.isRequired,
+    setAddModel: PropTypes.any.isRequired,
+    dataElements: PropTypes.any.isRequired,
+};
 
 const mapDispatchToProps = dispatch => bindActionCreators({ removeStageNotification, setEditModel, setAddModel }, dispatch);
 
@@ -55,8 +70,10 @@ const enhance = compose(
         },
     }),
     mapPropsStream(props$ => props$
-        .combineLatest(notifications$, (props, notifications) => ({ ...props, notifications }))
-    )
+        .combineLatest(notifications$, programStageDataElements$, (props, notifications, dataElements) =>
+            ({ ...props, notifications, dataElements })
+        )
+    ),
 );
 
 export default enhance(EventProgramNotifications);

--- a/src/EditModel/event-program/notifications/NotificationDialog.js
+++ b/src/EditModel/event-program/notifications/NotificationDialog.js
@@ -1,25 +1,30 @@
 import React, { PropTypes, Component } from 'react';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { get } from 'lodash/fp';
+
 import FlatButton from 'material-ui/FlatButton';
 import Dialog from 'material-ui/Dialog';
-import { createStepperFromConfig } from '../../stepper/stepper';
+
 import withState from 'recompose/withState';
 import compose from 'recompose/compose';
 import withProps from 'recompose/withProps';
-import { modelToEditSelector } from './selectors';
-import { setEditModel, setStageNotificationValue, saveStageNotification } from './actions';
-import { bindActionCreators } from 'redux';
-import { get } from 'lodash/fp';
-import { createFieldConfigsFor } from '../../formHelpers';
-import FormBuilder from 'd2-ui/lib/forms/FormBuilder.component';
 import branch from 'recompose/branch';
 import renderNothing from 'recompose/renderNothing';
 
-const mapStateToProps = state => ({
+import FormBuilder from 'd2-ui/lib/forms/FormBuilder.component';
+
+import { createStepperFromConfig } from '../../stepper/stepper';
+import { modelToEditSelector } from './selectors';
+import { setEditModel, setStageNotificationValue, saveStageNotification } from './actions';
+import { createFieldConfigsFor } from '../../formHelpers';
+
+const mapStateToProps = (state, { dataElements }) => ({
     model: modelToEditSelector(state),
+    dataElements,
 });
 
-const _mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = dispatch => ({
     onUpdateField(fieldName, value) {
         dispatch(setStageNotificationValue(fieldName, value));
     },
@@ -71,23 +76,33 @@ const steps = [
         key: 'what',
         name: 'what_to_send',
         content: compose(
-            connect(mapStateToProps, _mapDispatchToProps, undefined, { pure: false }),
+            connect(mapStateToProps, mapDispatchToProps, undefined, { pure: false }),
             createFieldConfigsFor(
                 'programNotificationTemplate',
                 ['name', 'messageTemplate'],
             ),
         )(class extends Component {
             componentDidMount() {
-                // FIXME: Hack to reposition the dialog when the first step is clicked (https://github.com/callemall/material-ui/issues/5793)
-                setTimeout(() => window.dispatchEvent(new Event('resize')), 600);
+                // Hack to reposition the dialog when the first step is clicked (Material-UI bug)
+                setTimeout(() => window.dispatchEvent(new Event('resize')), 50);
+                // Dispatch a resize event immediately to avoid the jerking around with the dialog
+                requestAnimationFrame(() => window.dispatchEvent(new Event('resize')));
             }
 
             render() {
-                const { fieldConfigs = [], onUpdateField } = this.props;
+                // eslint-disable-next-line react/prop-types
+                const { fieldConfigs = [], onUpdateField, dataElements } = this.props;
+                const addDataElementsToMessageTemplateField = fieldConfig => (
+                    fieldConfig.name === 'messageTemplate'
+                        ? Object.assign({}, fieldConfig, {
+                            props: Object.assign({}, fieldConfig.props, { dataElements }),
+                        })
+                        : fieldConfig
+                );
 
                 return (
                     <FormBuilder
-                        fields={fieldConfigs}
+                        fields={fieldConfigs.map(addDataElementsToMessageTemplateField)}
                         onUpdateField={onUpdateField}
                     />
                 );
@@ -99,7 +114,7 @@ const steps = [
         name: 'when_to_send_it',
         content:
             compose(
-                connect(mapStateToProps, _mapDispatchToProps, undefined, { pure: false }),
+                connect(mapStateToProps, mapDispatchToProps, undefined, { pure: false }),
                 createFieldConfigsFor(
                     'programNotificationTemplate',
                     ['notificationTrigger', 'relativeScheduledDays'],
@@ -117,7 +132,7 @@ const steps = [
         name: 'who_to_send_it_to',
         content:
             compose(
-                connect(mapStateToProps, _mapDispatchToProps, undefined, { pure: false }),
+                connect(mapStateToProps, mapDispatchToProps, undefined, { pure: false }),
                 createFieldConfigsFor(
                     'programNotificationTemplate',
                     ['notificationRecipient', 'recipientUserGroup', 'deliveryChannels'],
@@ -134,10 +149,11 @@ const steps = [
 
 const Stepper = compose(
     withState('activeStep', 'setActiveStep', 0),
-    withProps(({ setActiveStep }) => ({
+    withProps(({ setActiveStep, dataElements }) => ({
         stepperClicked(stepKey) {
             setActiveStep(steps.findIndex(step => step.key === stepKey));
         },
+        dataElements,
     })),
 )(createStepperFromConfig(steps, 'vertical'));
 
@@ -149,7 +165,7 @@ const notificationDialogStyle = {
     },
 };
 
-function NotificationDialog({ model, onCancel, onConfirm }, { d2 }) {
+function NotificationDialog({ model, onCancel, onConfirm, dataElements }, { d2 }) {
     const t = d2.i18n.getTranslation.bind(d2.i18n);
     const actions = [
         <FlatButton
@@ -174,20 +190,26 @@ function NotificationDialog({ model, onCancel, onConfirm }, { d2 }) {
             autoScrollBodyContent
             contentStyle={notificationDialogStyle.content}
         >
-            <Stepper />
+            <Stepper dataElements={dataElements} />
         </Dialog>
     );
 }
 NotificationDialog.contextTypes = {
     d2: PropTypes.object,
 };
+NotificationDialog.propTypes = {
+    model: PropTypes.object.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    onConfirm: PropTypes.func.isRequired,
+    dataElements: PropTypes.array.isRequired,
+};
 
-const mapDispatchToProps = dispatch => bindActionCreators({
+const mapDispatchToPropsForDialog = dispatch => bindActionCreators({
     onCancel: setEditModel.bind(null, null),
     onConfirm: saveStageNotification,
 }, dispatch);
 
 export default compose(
-    connect(mapStateToProps, mapDispatchToProps),
-    branch(({ model }) => !model, renderNothing)
+    connect(mapStateToProps, mapDispatchToPropsForDialog),
+    branch(({ model }) => !model, renderNothing),
 )(NotificationDialog);

--- a/src/EditModel/event-program/notifications/NotificationDialog.js
+++ b/src/EditModel/event-program/notifications/NotificationDialog.js
@@ -83,7 +83,8 @@ const steps = [
             ),
         )(class extends Component {
             componentDidMount() {
-                // Hack to reposition the dialog when the first step is clicked (Material-UI bug)
+                // Hack to reposition the dialog when the first step is clicked
+                // Material-UI issue: https://github.com/callemall/material-ui/issues/5793
                 setTimeout(() => window.dispatchEvent(new Event('resize')), 50);
                 // Dispatch a resize event immediately to avoid the jerking around with the dialog
                 requestAnimationFrame(() => window.dispatchEvent(new Event('resize')));

--- a/src/EditModel/event-program/notifications/selectors.js
+++ b/src/EditModel/event-program/notifications/selectors.js
@@ -1,6 +1,15 @@
 import { get, compose, first, __ } from 'lodash/fp';
 
-export const getStageNotifications = ({ programStages, programStageNotifications }) => compose(get(__, programStageNotifications), get('id'), first)(programStages);
+export const getStageNotifications = ({ programStages, programStageNotifications }) =>
+    compose(get(__, programStageNotifications), get('id'), first)(programStages);
+
+export const getProgramStageDataElements = ({ programStages, availableDataElements }) => {
+    const programStageDataElements = programStages[0].programStageDataElements
+        .map(psde => psde.dataElement.id);
+
+    return availableDataElements
+        .filter(de => programStageDataElements.includes(de.id));
+};
 
 export const isDeletingSelector = get('eventProgram.stageNotifications.isDeleting');
 export const objectNameToBeDeletedSelector = get('eventProgram.stageNotifications.objectNameToBeDeleted');

--- a/src/EditModel/stepper/stepper.js
+++ b/src/EditModel/stepper/stepper.js
@@ -43,14 +43,14 @@ function isActiveStep(activeStep, step, index) {
  * // <MyStepperComponent activeStep={activeStep.key} />
  * ```
  */
-export const createStepperFromConfig = (stepperConfig, orientation = 'horizontal') => ({ activeStep, stepperClicked }) => {
+export const createStepperFromConfig = (stepperConfig, orientation = 'horizontal') => ({ activeStep, stepperClicked,...props }) => {
     const getStepChildren = (step) => {
         const stepChildren = [];
 
         stepChildren.push(<StepButton key="button" onClick={() => stepperClicked(step.key)}><Translate>{step.name}</Translate></StepButton>);
 
         if (step.content) {
-            stepChildren.push(<StepContent key="content"><step.content /></StepContent>);
+            stepChildren.push(<StepContent key="content"><step.content {...props} /></StepContent>);
         }
 
         return stepChildren;

--- a/src/EditModel/stepper/stepper.js
+++ b/src/EditModel/stepper/stepper.js
@@ -43,7 +43,7 @@ function isActiveStep(activeStep, step, index) {
  * // <MyStepperComponent activeStep={activeStep.key} />
  * ```
  */
-export const createStepperFromConfig = (stepperConfig, orientation = 'horizontal') => ({ activeStep, stepperClicked,...props }) => {
+export const createStepperFromConfig = (stepperConfig, orientation = 'horizontal') => ({ activeStep, stepperClicked, ...props }) => {
     const getStepChildren = (step) => {
         const stepChildren = [];
 

--- a/src/config/field-overrides/programNotificationTemplate.js
+++ b/src/config/field-overrides/programNotificationTemplate.js
@@ -22,6 +22,7 @@ const PROGRAM_STAGE_VARIABLES = [
 
 const toVariableType = name => ['V', name];
 const toAttributeType = name => ['A', name]; // Used for program attributes
+const toDataElementType = name => ['#', name];
 
 const ProgramStageNotificationSubjectAndMessageTemplateFields = compose(
     connect(undefined, dispatch => bindActionCreators({
@@ -29,9 +30,9 @@ const ProgramStageNotificationSubjectAndMessageTemplateFields = compose(
     },
         dispatch
     )),
-    withProps({
-        variableTypes: map(toVariableType, PROGRAM_STAGE_VARIABLES),
-    }))(SubjectAndMessageTemplateFields);
+    withProps(({ dataElements }) => ({
+        variableTypes: map(toVariableType, PROGRAM_STAGE_VARIABLES).concat(map(toDataElementType, dataElements)),
+    })))(SubjectAndMessageTemplateFields);
 
 export default new Map([
     ['deliveryChannels', {

--- a/src/config/field-overrides/validation-notification-template/SubjectAndMessageTemplateFields.js
+++ b/src/config/field-overrides/validation-notification-template/SubjectAndMessageTemplateFields.js
@@ -8,10 +8,12 @@ import { map, compose } from 'lodash/fp';
 
 function prepareProps(d2, onItemSelected) {
     return function ([type, name]) {
+        const label = name.displayName ? name.displayName : d2.i18n.getTranslation(name);
+        const varName = name.id ? name.id : name;
         return {
-            primaryText: d2.i18n.getTranslation(name),
+            primaryText: label,
             onClick() {
-                onItemSelected(`${type}{${name}}`);
+                onItemSelected(`${type}{${varName}}`);
             },
         };
     };


### PR DESCRIPTION
Adds the list of data elements assigned to a program to the list of template variables in the program notification editor. Clicking a data element in the list inserts the relevant code in the subject or message template (whichever is currently active), on the form `#{uid}`.