### PR TITLE
DHIS2-2643 Do not wrap words inside the program rule variable components

### DIFF
--- a/src/config/field-overrides/program-rules/programRuleConditionField.component.js
+++ b/src/config/field-overrides/program-rules/programRuleConditionField.component.js
@@ -164,10 +164,11 @@ class ProgramRuleConditionField extends React.Component {
                 <RaisedButton
                     key={i}
                     label={varLabel}
-                    labelStyle={{ textTransform: 'none' }}
+                    labelStyle={{ textTransform: 'none', whiteSpace: 'nowrap' }}
                     style={styles.insertButton}
                     disabled={this.props.disabled}
                     onClick={makeTextPusher(varText)}
+                    title={varText}
                 />
             );
         };
@@ -211,10 +212,11 @@ class ProgramRuleConditionField extends React.Component {
                             <RaisedButton
                                 key={i}
                                 label={f}
-                                labelStyle={{ textTransform: 'none' }}
+                                labelStyle={{ textTransform: 'none', whiteSpace: 'nowrap' }}
                                 style={styles.insertButton}
                                 disabled={this.props.disabled}
                                 onClick={makeTextPusher(f)}
+                                title={f}
                             />
                         ))}
                     </div>


### PR DESCRIPTION
The height of these components are locked to 36px, which causes issues
if the text is allowed to wrap inside. It would be better to just show
the label on one line and allow the user to hover the label to see the
full name.