### PR TITLE
DHIS2-2444 Add programTrackedEntityAttributes to field filtering req

### DIFF
--- a/src/OrganisationUnitLevels/organisationUnitLevels.actions.js
+++ b/src/OrganisationUnitLevels/organisationUnitLevels.actions.js
@@ -28,6 +28,7 @@ function DropDownFieldForOfflineLevels(props) {
         </SelectField>
     );
 }
+
 DropDownFieldForOfflineLevels.propTypes = {
     options: PropTypes.array,
 };

--- a/src/forms/form-fields/drop-down-async.js
+++ b/src/forms/form-fields/drop-down-async.js
@@ -37,9 +37,15 @@ export default React.createClass({
             fieldsForReferenceType = 'id,displayName,name,valueType';
         }
 
+
         // program.programType is required for programIndicators to be able to determine if it is a tracker or event program
         if (this.props.referenceType === 'program') {
-            fieldsForReferenceType = 'id,displayName,name,programType';
+            /*
+             * DHIS-2444: program.programTrackedEntity is needed for the
+             * attributeselector to work when changing programs.
+             */
+
+            fieldsForReferenceType = 'id,displayName,programType,programTrackedEntityAttributes[id,trackedEntityAttribute[id,displayName,valueType]]';
         }
 
         const filter = this.props.queryParamFilter;


### PR DESCRIPTION
There was a field filtering override in the drop-down-async which
did not get enough data to populate the attribute selector in a program
indicator.