### PR TITLE
DHIS2-2683 Remove callbacks from the `onEnter` handlers

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -14,10 +14,9 @@ import store from './store';
 import { resetActiveStep } from './EditModel/actions';
 import { loadEventProgram } from './EditModel/event-program/actions';
 import { loadProgramIndicator } from './EditModel/program-indicator/actions';
+import { noop } from 'lodash/fp';
 
 import onDemand from './on-demand';
-
-function noop () {}
 
 function initState({ params }) {
     initAppState({

--- a/src/router.js
+++ b/src/router.js
@@ -17,6 +17,8 @@ import { loadProgramIndicator } from './EditModel/program-indicator/actions';
 
 import onDemand from './on-demand';
 
+function noop () {}
+
 function initState({ params }) {
     initAppState({
         sideBar: {
@@ -53,8 +55,10 @@ function initStateOuHierarchy() {
     });
 }
 
-// TODO: We could use an Observable that manages the current modelType to load the correct d2.Model. This would clean up the load function below.
-function loadObject({ params }, replace, callback) {
+// TODO: We could use an Observable that manages the current modelType
+// to load the correct d2.Model. This would clean up the load function
+// below.
+function loadObject({ params }, replace) {
     initState({ params });
 
     if (params.modelId === 'add') {
@@ -62,10 +66,12 @@ function loadObject({ params }, replace, callback) {
             const modelToEdit = d2.models[params.modelType].create();
 
             // Set the parent for the new organisationUnit to the selected OU
-            // TODO: Should probably be able to do this in a different way when this becomes needed for multiple object types
+            // TODO: Should probably be able to do this in a different
+            // way when this becomes needed for multiple object types
             if (params.modelType === 'organisationUnit') {
                 return appState
-                // Just take the first value as we don't want this observer to keep updating the state
+                    // Just take the first value as we don't want this
+                    // observer to keep updating the state
                     .take(1)
                     .subscribe((state) => {
                         if (state.selectedOrganisationUnit && state.selectedOrganisationUnit.id) {
@@ -75,7 +81,6 @@ function loadObject({ params }, replace, callback) {
                         }
 
                         modelToEditStore.setState(modelToEdit);
-                        callback();
                     });
             }
 
@@ -90,43 +95,41 @@ function loadObject({ params }, replace, callback) {
                     }, {});
 
             modelToEditStore.setState(Object.assign(modelToEdit, listFilters));
-            return callback();
         });
     } else {
         objectActions.getObjectOfTypeById({ objectType: params.modelType, objectId: params.modelId })
             .subscribe(
-                () => callback(),
+                noop,
                 (errorMessage) => {
                     replace(`/list/${params.modelType}`);
                     snackActions.show({ message: errorMessage, action: 'ok' });
-                    callback();
                 }
             );
     }
 }
 
-function loadOrgUnitObject({ params }, replace, callback) {
+function loadOrgUnitObject({ params }, replace) {
     loadObject({
         params: {
             modelType: 'organisationUnit',
             groupName: params.groupName,
             modelId: params.modelId,
         },
-    }, replace, callback);
+    }, replace);
 }
 
-function loadOptionSetObject({ params }, replace, callback) {
+function loadOptionSetObject({ params }, replace) {
     loadObject({
         params: {
             modelType: 'optionSet',
             groupName: params.groupName,
             modelId: params.modelId,
         },
-    }, replace, callback);
+    }, replace);
 }
 
 function createLoaderForSchema(schema, actionCreatorForLoadingObject, resetActiveStep) {
-    return ({ params }, replace, callback) => {
+    return ({ params }, replace) => {
         initState({
             params: {
                 modelType: schema,
@@ -138,56 +141,48 @@ function createLoaderForSchema(schema, actionCreatorForLoadingObject, resetActiv
         // Fire load action for the event program program to be edited
         store.dispatch(actionCreatorForLoadingObject({ schema, id: params.modelId }));
         store.dispatch(resetActiveStep());
-
-        callback();
     };
 }
 
-function loadList({ params }, replace, callback) {
+function loadList({ params }, replace) {
     if (params.modelType === 'organisationUnit') {
-        // Don't load organisation units as they get loaded through the appState
-        // Also load the initialState without cache so we refresh the assigned organisation units
-        // These could have changed by adding an organisation unit which would need to be reflected in the
-        // organisation unit tree
+        // Don't load organisation units as they get loaded through the
+        // appState Also load the initialState without cache so we
+        // refresh the assigned organisation units These could have
+        // changed by adding an organisation unit which would need to be
+        // reflected in the organisation unit tree
         initState({ params });
-        return callback();
     }
 
     initState({ params });
     return listActions.loadList(params.modelType)
         .take(1)
         .subscribe(
-            (message) => {
-                log.debug(message);
-                callback();
-            },
+            noop,
             (message) => {
                 if (/^.+s$/.test(params.modelType)) {
                     const nonPluralAttempt = params.modelType.substring(0, params.modelType.length - 1);
                     log.warn(`Could not find requested model type '${params.modelType}' attempting to redirect to '${nonPluralAttempt}'`);
                     replace(`list/${nonPluralAttempt}`);
-                    callback();
                 } else {
                     log.error('No clue where', params.modelType, 'comes from... Redirecting to app root');
                     log.error(message);
 
                     replace('/');
-                    callback();
                 }
             }
         );
 }
 
-function cloneObject({ params }, replace, callback) {
+function cloneObject({ params }, replace) {
     initState({ params });
 
     objectActions.getObjectOfTypeByIdAndClone({ objectType: params.modelType, objectId: params.modelId })
         .subscribe(
-            () => callback(),
+            noop,
             (errorMessage) => {
                 replace(`/list/${params.modelType}`);
                 snackActions.show({ message: errorMessage, action: 'ok' });
-                callback();
             }
         );
 }


### PR DESCRIPTION
Due to how HashHistory is implemented when it changes URL hashes
in v3 of react-router multiple events fires when we use
`HashHistory.push(url)`. This in turn causes the `onEnter` handler
in react-router to run twice.

The XHR request itself is cached so no extra data is transmitted from
the server but another consequence is that the components render twice
which has performance implications.

For more information see the [JIRA
issue](https://jira.dhis2.org/browse/DHIS2-2683).