### PR TITLE
Bug/field rule for hide field not working with stepper

### DIFF
--- a/src/EditModel/EditModelForm.component.js
+++ b/src/EditModel/EditModelForm.component.js
@@ -225,7 +225,7 @@ export default React.createClass({
                 activeStep: step,
                 fieldConfigs: this.state.fieldConfigs.map((field) => {
                     if (stepsByField[field.name] === step) {
-                        if (field.hiddenComponent) {
+                        if (field.hiddenComponent && !field.hasHiddenRule) {
                             field.component = field.hiddenComponent;
                             field.hiddenComponent = undefined;
                         }

--- a/src/EditModel/EditModelForm.component.js
+++ b/src/EditModel/EditModelForm.component.js
@@ -4,11 +4,12 @@ import log from 'loglevel';
 import { Observable } from 'rxjs';
 
 import { Step, Stepper, StepButton } from 'material-ui/Stepper';
+
+import { getInstance } from 'd2/lib/d2';
+import { isString } from 'd2-utilizr';
 import CircularProgress from 'd2-ui/lib/circular-progress/CircularProgress';
 import Translate from 'd2-ui/lib/i18n/Translate.mixin';
 import FormBuilder from 'd2-ui/lib/forms/FormBuilder.component';
-import { isString } from 'd2-utilizr';
-import { getInstance } from 'd2/lib/d2';
 
 import fieldGroups from '../config/field-config/field-groups';
 import disabledOnEdit from '../config/disabled-on-edit';
@@ -20,6 +21,7 @@ import CancelButton from './CancelButton.component';
 import SharingNotification from './SharingNotification.component';
 import FormButtons from './FormButtons.component';
 import extraFields from './extraFields';
+
 import appState from '../App/appStateStore';
 import { createFieldConfigForModelTypes, addUniqueValidatorWhenUnique, getAttributeFieldConfigs } from './formHelpers';
 import { applyRulesToFieldConfigs, getRulesForModelType } from './form-rules';
@@ -59,7 +61,6 @@ const modelToEditAndModelForm$ = Observable.combineLatest(modelToEditStore, edit
 
                 // Check if value is an attribute
                 if (Object.keys(modelToEdit.attributes || []).indexOf(fieldConfig.name) >= 0) {
-                    // console.log(fieldConfig.name, ' is an attribute');
                     fieldConfig.value = modelToEdit.attributes[fieldConfig.name];
                     return fieldConfig;
                 }
@@ -186,12 +187,6 @@ export default React.createClass({
             );
         }
 
-        const backButtonStyle = {
-            position: 'absolute',
-            left: 5,
-            top: 5,
-        };
-
         return (
             <div style={formPaperStyle}>
                 {this.renderStepper()}
@@ -221,25 +216,6 @@ export default React.createClass({
         return this.renderForm();
     },
 
-    /*
-        Will render the fields that are relevant for the current "step"
-        This is done by setting the fields "component" to an empty function
-        if it is not relevant. The component is saved in the variable "hiddenComponent".
-        When the stepper is set to a step in which the field is supposed to be rendered
-        the hiddenComponent will be set back to the component variable.
-
-        **HACK**
-        Since the field rules in EditModel/form-rules/index.js uses the same way to hide and show
-        fields with the HIDE_FIELD and SHOW_FIELD rule, this causes the rule not work using 
-        the stepper. Setting the style to 'display: none' will would work for the stepper and 
-        still allowing the rules to use "hiddenComponent" as a way to show and hide fields, 
-        but since not all component does not spread and merge style, it will not always work.
-        Whe all components uses spread style this hack can be removed.
-        
-        As a temporary workaround hack the "field.hasHiddenRule" added in index.js is checked as
-        a second predicate in the if statement below to avoid setting the component back from 
-        hiddeComponent and rendering the field. 
-    */
     setActiveStep(step) {
         const stepsByField = fieldGroups.groupsByField(this.props.modelType);
         if (stepsByField) {
@@ -247,19 +223,10 @@ export default React.createClass({
                 activeStep: step,
                 fieldConfigs: this.state.fieldConfigs.map((field) => {
                     if (stepsByField[field.name] === step) {
-                        if (field.hiddenComponent && !field.hasHiddenRule) {
-                            field.component = field.hiddenComponent;
-                            field.hiddenComponent = undefined;
-                        }
-                        field.props.style = { display: 'inline-block' };
+                        field.props.style = { display: 'block' };
                     } else {
-                        if (!field.hiddenComponent) {
-                            field.hiddenComponent = field.component;
-                            field.component = PlaceholderComponent;
-                        }
                         field.props.style = { display: 'none' };
                     }
-
                     return field;
                 }),
             });

--- a/src/EditModel/EditModelForm.component.js
+++ b/src/EditModel/EditModelForm.component.js
@@ -216,6 +216,11 @@ export default React.createClass({
         return this.renderForm();
     },
 
+    /*
+        Sets the style of the fields that are not part of the active steps to 'none'
+        so that they are "hidden". For this to work, the components needs to have
+        an outer div that receives the props.style. 
+    */
     setActiveStep(step) {
         const stepsByField = fieldGroups.groupsByField(this.props.modelType);
         if (stepsByField) {

--- a/src/EditModel/IndicatorExpressionManagerContainer.component.js
+++ b/src/EditModel/IndicatorExpressionManagerContainer.component.js
@@ -27,7 +27,7 @@ const IndicatorExpressionManagerContainer = React.createClass({
         indicatorExpressionChanged: React.PropTypes.func.isRequired,
         description: React.PropTypes.string.isRequired,
         formula: React.PropTypes.string.isRequired,
-        titleText: React.PropTypes.string.isRequired,
+        titleText: React.PropTypes.string,
     },
 
     mixins: [Translate],

--- a/src/EditModel/extraFields.js
+++ b/src/EditModel/extraFields.js
@@ -2,12 +2,12 @@ import React from 'react';
 import Dialog from 'material-ui/Dialog/Dialog';
 import RaisedButton from 'material-ui/RaisedButton/RaisedButton';
 import FlatButton from 'material-ui/FlatButton/FlatButton';
+import addD2Context from 'd2-ui/lib/component-helpers/addD2Context';
+
 import IndicatorExpressionManagerContainer from './IndicatorExpressionManagerContainer.component';
-import { Observable } from 'rxjs';
 import modelToEditStore from './modelToEditStore';
 import DataIndicatorGroupsAssignment from './DataIndicatorGroupsAssignment.component';
 import DataElementGroupsAssignment from './data-element/DataElementGroupsAssignment.component';
-import addD2Context from 'd2-ui/lib/component-helpers/addD2Context';
 
 const styles = {
     saveButton: {
@@ -32,6 +32,44 @@ class IndicatorExtraFields extends React.Component {
         this.closeDialog = this.closeDialog.bind(this);
         this.saveToModelAndCloseDialog = this.saveToModelAndCloseDialog.bind(this);
         this.indicatorExpressionChanged = this.indicatorExpressionChanged.bind(this);
+    }
+
+    setNumerator() {
+        this.setState({ type: 'numerator', dialogOpen: true });
+    }
+
+    setDenominator() {
+        this.setState({ type: 'denominator', dialogOpen: true });
+    }
+
+    closeDialog() {
+        this.setState({ dialogOpen: false });
+    }
+
+    saveToModelAndCloseDialog() {
+        if (this.state.expressionStatus.isValid) {
+            this.props.modelToEdit[this.state.type] = this.state.expressionFormula;
+            this.props.modelToEdit[`${this.state.type}Description`] = this.state.expressionDescription;
+
+            modelToEditStore.setState(this.props.modelToEdit);
+        }
+
+        this.setState({ dialogOpen: false });
+    }
+
+    indicatorExpressionChanged(data) {
+        const expressionValues = {};
+
+        if (data.expressionStatus.isValid) {
+            expressionValues.expressionStatus = data.expressionStatus;
+            expressionValues.expressionDescription = data.description;
+            expressionValues.expressionFormula = data.formula;
+        }
+
+        this.setState({
+            dialogValid: data.expressionStatus.isValid && Boolean(data.description.trim()),
+            ...expressionValues,
+        });
     }
 
     renderExpressionManager() {
@@ -77,49 +115,10 @@ class IndicatorExtraFields extends React.Component {
             </div>
         );
     }
-
-    setNumerator() {
-        this.setState({ type: 'numerator', dialogOpen: true });
-    }
-
-    setDenominator() {
-        this.setState({ type: 'denominator', dialogOpen: true });
-    }
-
-    closeDialog() {
-        this.setState({ dialogOpen: false });
-    }
-
-    saveToModelAndCloseDialog() {
-        if (this.state.expressionStatus.isValid) {
-            this.props.modelToEdit[this.state.type] = this.state.expressionFormula;
-            this.props.modelToEdit[`${this.state.type}Description`] = this.state.expressionDescription;
-
-            modelToEditStore.setState(this.props.modelToEdit);
-        }
-
-        this.setState({ dialogOpen: false });
-    }
-
-    indicatorExpressionChanged(data) {
-        const expressionValues = {};
-
-        if (data.expressionStatus.isValid) {
-            expressionValues.expressionStatus = data.expressionStatus;
-            expressionValues.expressionDescription = data.description;
-            expressionValues.expressionFormula = data.formula;
-        }
-
-        this.setState({
-            dialogValid: data.expressionStatus.isValid && Boolean(data.description.trim()),
-            ...expressionValues,
-        });
-    }
 }
+
 IndicatorExtraFields.propTypes = {
     modelToEdit: React.PropTypes.object.isRequired,
-    description: React.PropTypes.string.isRequired,
-    formula: React.PropTypes.string.isRequired,
 };
 
 export default {
@@ -130,7 +129,7 @@ export default {
                 <div style={{ marginTop: '2rem' }}>
                     <DataElementGroupsAssignment source={props.modelToEdit} />
                 </div>
-                ),
+            ),
         },
     ],
     indicator: [

--- a/src/EditModel/form-rules/index.js
+++ b/src/EditModel/form-rules/index.js
@@ -44,6 +44,12 @@ function setProp(fieldConfig, operationParams, ruleResult) {
     return fieldConfig.props[operationParams.propName] = operationParams.elseValue;
 }
 
+
+/*
+    Uses the swapping variable "hiddenComponent" when temporary hiding a field.
+    When the field should be shown again, the content of "hiddenComponent" is
+    put back to the "component" variable.
+*/
 function hideField(fieldConfig, operationParams, ruleResult) {
     if (ruleResult) {
         fieldConfig.hiddenComponent = fieldConfig.hiddenComponent || fieldConfig.component;
@@ -140,9 +146,15 @@ export function applyRulesToFieldConfigs(rules, fieldConfigs, modelToEdit) {
             (rule.operations || [rule.operation])
                 .forEach((operation) => {
                     const fieldConfigForOperation = fieldConfigs.find(fieldConfig => fieldConfig.name === (operation.field || rule.field));
-                    const { field, type, ...operationParams } = operation;
+                    const {
+                        field,
+                        type,
+                        ...operationParams
+                    } = operation;
 
-                    log.debug(`---- For field ${field || rule.field} execute ${getOperation(type).name} with`, operationParams);
+                    log.debug(`---- For field ${field || rule.field} 
+                            execute ${getOperation(type).name} 
+                            with`, operationParams);
 
                     getOperation(type)(fieldConfigForOperation, operationParams, rulePassed, modelToEdit);
                 });

--- a/src/EditModel/form-rules/index.js
+++ b/src/EditModel/form-rules/index.js
@@ -44,14 +44,8 @@ function setProp(fieldConfig, operationParams, ruleResult) {
     return fieldConfig.props[operationParams.propName] = operationParams.elseValue;
 }
 
-/*
-    Needed to add an extra variable for "hasHiddenRule" since EditModelForm.component->setActiveStep() uses 
-    the field.hiddenComponent variable to hide and unhide fields that are not relevant for the 
-    same step using the stepper. 
-*/
 function hideField(fieldConfig, operationParams, ruleResult) {
     if (ruleResult) {
-        fieldConfig.hasHiddenRule = true;
         fieldConfig.hiddenComponent = fieldConfig.hiddenComponent || fieldConfig.component;
         fieldConfig.component = () => null;
     } else if (fieldConfig.hiddenComponent) {

--- a/src/EditModel/form-rules/index.js
+++ b/src/EditModel/form-rules/index.js
@@ -44,6 +44,11 @@ function setProp(fieldConfig, operationParams, ruleResult) {
     return fieldConfig.props[operationParams.propName] = operationParams.elseValue;
 }
 
+/*
+    Needed to add an extra variable for "hasHiddenRule" since EditModelForm.component->setActiveStep() uses 
+    the field.hiddenComponent variable to hide and unhide fields that are not relevant for the 
+    same step using the stepper. 
+*/
 function hideField(fieldConfig, operationParams, ruleResult) {
     if (ruleResult) {
         fieldConfig.hasHiddenRule = true;

--- a/src/EditModel/form-rules/index.js
+++ b/src/EditModel/form-rules/index.js
@@ -44,8 +44,9 @@ function setProp(fieldConfig, operationParams, ruleResult) {
     return fieldConfig.props[operationParams.propName] = operationParams.elseValue;
 }
 
-function hideField(fieldConfig, operationParams, ruleResult, x) {
+function hideField(fieldConfig, operationParams, ruleResult) {
     if (ruleResult) {
+        fieldConfig.hasHiddenRule = true;
         fieldConfig.hiddenComponent = fieldConfig.hiddenComponent || fieldConfig.component;
         fieldConfig.component = () => null;
     } else if (fieldConfig.hiddenComponent) {

--- a/src/List/List.component.js
+++ b/src/List/List.component.js
@@ -343,7 +343,7 @@ const List = React.createClass({
                                     value={this.state.filters ? this.state.filters[filterField] : null}
                                     quickAddLink={false}
                                     preventAutoDefault
-                                    styles={{ display: 'relative' }}
+                                    style={{ display: 'relative' }}
                                     limit={1}
                                     top={-15}
                                 />

--- a/src/config/field-config/field-groups.js
+++ b/src/config/field-config/field-groups.js
@@ -1,5 +1,13 @@
 import fieldOrder from './field-order';
 
+/*
+    The stepper sets the style of the fields of the not active step to "display: none"
+    to hide them from view. For this to work the component of the field needs to recieve 
+    the style from props. If the fields are not hidden when changing the active step
+    then check if the component of the corresponding fields are receiving and using the 
+    style from props in its outer div. 
+*/
+
 const fieldGroupsForModelType = new Map([
     ['programRule', [
         {

--- a/src/config/field-config/field-order.js
+++ b/src/config/field-config/field-order.js
@@ -237,7 +237,7 @@ const fieldOrderByName = new Map([
         'name',
         'description',
         'minAttributesRequiredToSearch',
-        'maxTeiCountToReturn'
+        'maxTeiCountToReturn',
     ]],
     ['programIndicator', [
         'program',

--- a/src/config/field-overrides/programNotificationTemplate.js
+++ b/src/config/field-overrides/programNotificationTemplate.js
@@ -28,7 +28,7 @@ const ProgramStageNotificationSubjectAndMessageTemplateFields = compose(
     connect(undefined, dispatch => bindActionCreators({
         onUpdate: ({ fieldName, value }) => setStageNotificationValue(fieldName, value),
     },
-        dispatch
+    dispatch,
     )),
     withProps(({ dataElements }) => ({
         variableTypes: map(toVariableType, PROGRAM_STAGE_VARIABLES).concat(map(toDataElementType, dataElements)),

--- a/src/config/field-overrides/validation-notification-template/SubjectAndMessageTemplateFields.js
+++ b/src/config/field-overrides/validation-notification-template/SubjectAndMessageTemplateFields.js
@@ -96,10 +96,13 @@ export default class SubjectAndMessageTemplateFields extends Component {
             subject: {
                 flex: '0 0 72px',
             },
+            fieldWrap: {
+                position: 'relative',
+            },
         };
 
         return (
-            <div>
+            <div style={{ ...styles.fieldWrap, ...this.props.style }}>
                 <Divider style={styles.divider} />
                 <Heading level={3} style={styles.heading}>Message template</Heading>
                 <Row>

--- a/src/config/field-overrides/validationNotificationTemplate.js
+++ b/src/config/field-overrides/validationNotificationTemplate.js
@@ -24,14 +24,14 @@ const toVariableType = name => ['V', name];
 const toAttributeType = name => ['A', name];
 
 const ValidationNotificationSubjectAndMessageTemplateFields = compose(
-        withProps({
-            variableTypes: map(toVariableType, VALIDATION_RULE_VARIABLES),
-        }),
-        mapProps(props => ({
-            ...props,
-            onUpdate: actions.update,
-        }))
-    )(SubjectAndMessageTemplateFields);
+    withProps({
+        variableTypes: map(toVariableType, VALIDATION_RULE_VARIABLES),
+    }),
+    mapProps(props => ({
+        ...props,
+        onUpdate: actions.update,
+    })),
+)(SubjectAndMessageTemplateFields);
 
 export default new Map([
     ['messageTemplate', {

--- a/src/forms/fields.js
+++ b/src/forms/fields.js
@@ -1,8 +1,6 @@
 import { isRequired, isUrl, isNumber as isNumberValidator, isEmail } from 'd2-ui/lib/forms/Validators';
 import isString from 'd2-utilizr/lib/isString';
 import isNumber from 'lodash.isnumber';
-import log from 'loglevel';
-import { config, getInstance } from 'd2/lib/d2';
 import TextField from './form-fields/text-field';
 import MultiSelect from './form-fields/multi-select';
 import CheckBox from './form-fields/check-box';

--- a/src/forms/form-fields/date-select.js
+++ b/src/forms/form-fields/date-select.js
@@ -26,15 +26,18 @@ export default React.createClass({
             modelDefinition,
             ...other
         } = this.props;
+
         return (
-            <DatePicker
-                {...other}
-                value={this.props.value && new Date(this.props.value)}
-                mode="portrait"
-                autoOk
-                floatingLabelText={labelText}
-                onChange={this._onDateSelect}
-            />
+            <div style={{ ...this.props.style }}>
+                <DatePicker
+                    {...other}
+                    value={this.props.value && new Date(this.props.value)}
+                    mode="portrait"
+                    autoOk
+                    floatingLabelText={labelText}
+                    onChange={this._onDateSelect}
+                />
+            </div>
         );
     },
 

--- a/src/forms/form-fields/drop-down-async.js
+++ b/src/forms/form-fields/drop-down-async.js
@@ -69,11 +69,10 @@ export default React.createClass({
                         .map(v => ({ displayName: d2.i18n.getTranslation(v.toLowerCase()), id: v }));
                 }
             })
-            .then(modelCollection => modelCollection
-                ? (modelCollection.toArray
-                    ? modelCollection.toArray()
-                    : modelCollection)
-                : [])
+            .then(modelCollection => (
+                modelCollection
+                    ? (modelCollection.toArray ? modelCollection.toArray() : modelCollection)
+                    : []))
             .then(values => values.map(model => ({
                 text: model.displayName,
                 value: model.id,
@@ -91,7 +90,7 @@ export default React.createClass({
                             option.model.modelDefinition.name === 'categoryCombo' &&
                             option.text === 'default'
                                 ? { text: d2i.i18n.getTranslation('none') }
-                                : {}
+                                : {},
                         )),
                     });
                 }
@@ -139,34 +138,43 @@ export default React.createClass({
             queryParamFilter,
             quickAddLink,
             preventAutoDefault,
-            styles,
+            style,
             ...other
         } = this.props;
-        const wrapStyles = Object.assign({
-            display: 'flex',
-            alignItems: 'flex-end',
-        }, styles);
+
+        const styles = {
+            fieldStyle: {
+                display: 'flex',
+                alignItems: 'flex-end',
+            },
+            fieldWrap: {
+                position: 'relative',
+            },
+        };
 
         return (
-            <div style={wrapStyles}>
-                {this.state.isRefreshing ? <RefreshMask horizontal /> : null}
-                <DropDown
-                    {...other}
-                    options={this.state.options}
-                    value={this.props.value ? this.props.value.id : undefined}
-                    onChange={this._onChange}
-                    fullWidth
-                />
-                {quickAddLink ?
-                    <QuickAddLink
-                        referenceType={this.props.referenceType}
-                        onRefreshClick={this._onRefreshClick}
+            <div style={{ ...styles.fieldWrap, ...style }}>
+                <div style={styles.fieldStyle}>
+                    {this.state.isRefreshing ? <RefreshMask horizontal /> : null}
+                    <DropDown
+                        {...other}
+                        options={this.state.options}
+                        value={this.props.value ? this.props.value.id : undefined}
+                        onChange={this._onChange}
+                        fullWidth
                     />
-                : null}
+                    {quickAddLink ?
+                        <QuickAddLink
+                            referenceType={this.props.referenceType}
+                            onRefreshClick={this._onRefreshClick}
+                        />
+                        : null}
+                </div>
             </div>
         );
     },
 
+    // Doesnt seem to be in use. Can be removed
     renderQuickAddLink() {
         const sectionForReferenceType = getSectionForType(this.props.referenceType);
 

--- a/src/forms/form-fields/drop-down.js
+++ b/src/forms/form-fields/drop-down.js
@@ -6,7 +6,6 @@ import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
 import MenuItem from 'material-ui/MenuItem/MenuItem';
 
-
 class Dropdown extends React.Component {
     constructor(props, context) {
         super(props, context);
@@ -26,7 +25,6 @@ class Dropdown extends React.Component {
 
     componentWillReceiveProps(newProps) {
         this.setState({
-            // value: this.state.value || ((newProps.defaultValue !== undefined && newProps.defaultValue !== null) ? newProps.defaultValue : ''),
             options: this.getOptions(newProps.options, newProps.isRequired),
         });
     }
@@ -82,88 +80,6 @@ class Dropdown extends React.Component {
         );
     }
 
-    render() {
-        const {
-            onFocus,
-            onBlur,
-            labelText,
-            modelDefinition,
-            models,
-            referenceType,
-            referenceProperty,
-            isInteger,
-            translateOptions,
-            isRequired,
-            options,
-            model,
-            limit,
-            fullWidth,
-            top,
-            translateLabel,
-            style,
-            ...other
-        } = this.props;
-
-        if (style && style.display && style.display === 'none') {
-            return null;
-        }
-
-        return this.state.options.length > limit
-            ? (
-                <div style={{ width: fullWidth ? '100%' : 'inherit', position: 'relative', top: top || undefined }}>
-                    <Dialog
-                        title={labelText}
-                        open={this.state.dialogOpen}
-                        onRequestClose={this.closeDialog}
-                        autoScrollBodyContent
-                        autoDetectWindowHeight
-                        actions={[
-                            <FlatButton onClick={this.closeDialog} label={this.getTranslation('cancel')} />,
-                        ]}
-                    >
-                        <TextField
-                            floatingLabelText="Filter list"
-                            onChange={(e, value) => { this.setState({ filterText: value }); }}
-                            style={{ marginBottom: 16 }}
-                        />
-                        {!this.props.isRequired && this.renderDialogOption(null, this.getTranslation('no_value'))}
-                        {this.state.options
-                            .filter(o => !this.state.filterText || this.state.filterText
-                                .trim().toLocaleLowerCase().split(' ').every(
-                                    f => o.text.toLocaleLowerCase().includes(f.toLocaleLowerCase())
-                                )
-                            )
-                            .map(o => this.renderDialogOption(o.value, o.text))
-                        }
-                    </Dialog>
-                    <TextField
-                        {...other}
-                        fullWidth={fullWidth}
-                        value={this.getOptionText(this.state.value)}
-                        onClick={this.openDialog}
-                        onChange={this.openDialog}
-                        floatingLabelText={labelText}
-                        inputStyle={{ cursor: 'pointer' }}
-                    />
-                    <div
-                        style={{ position: 'absolute', top: 36, right: 10, color: 'rgba(0,0,0,0.25)', cursor: 'pointer' }}
-                        className="material-icons"
-                        onClick={this.openDialog}
-                    >open_in_new</div>
-                </div>
-            ) : (
-                <SelectField
-                    value={this.state.value}
-                    fullWidth={fullWidth}
-                    {...other}
-                    onChange={this._onChange}
-                    floatingLabelText={labelText}
-                >
-                    {this.renderOptions()}
-                </SelectField>
-            );
-    }
-
     renderOptions() {
         const options = this.state.options
             .map((option, index) => (
@@ -191,24 +107,129 @@ class Dropdown extends React.Component {
 
         return options;
     }
+
+    renderSelectField(other) {
+        return (
+            <SelectField
+                value={this.state.value}
+                fullWidth={this.props.fullWidth}
+                {...other}
+                onChange={this._onChange}
+                floatingLabelText={this.props.labelText}
+            >
+                {this.renderOptions()}
+            </SelectField>
+        );
+    }
+
+    renderDialogDropDown(other) {
+        const styles = {
+            fieldStyle: {
+                width: this.props.fullWidth ? '100%' : 'inherit',
+                position: 'relative',
+                top,
+            },
+            textField: {
+                marginBottom: 16,
+            },
+            openInNew: {
+                position: 'absolute',
+                top: 36,
+                right: 10,
+                color: 'rgba(0,0,0,0.25)',
+                cursor: 'pointer',
+            },
+        };
+
+        return (
+            <div style={styles.fieldStyle}>
+                <Dialog
+                    title={this.props.labelText}
+                    open={this.state.dialogOpen}
+                    onRequestClose={this.closeDialog}
+                    autoScrollBodyContent
+                    autoDetectWindowHeight
+                    actions={[
+                        <FlatButton onClick={this.closeDialog} label={this.getTranslation('cancel')} />,
+                    ]}
+                >
+                    <TextField
+                        floatingLabelText="Filter list"
+                        onChange={(e, value) => { this.setState({ filterText: value }); }}
+                        style={styles.textField}
+                    />
+                    {!this.props.isRequired && this.renderDialogOption(null, this.getTranslation('no_value'))}
+                    {this.state.options
+                        .filter(o => !this.state.filterText || this.state.filterText
+                            .trim().toLocaleLowerCase().split(' ').every(
+                                f => o.text.toLocaleLowerCase().includes(f.toLocaleLowerCase()),
+                            ),
+                        )
+                        .map(o => this.renderDialogOption(o.value, o.text))
+                    }
+                </Dialog>
+                <TextField
+                    {...other}
+                    fullWidth={this.props.fullWidth}
+                    value={this.getOptionText(this.state.value)}
+                    onClick={this.openDialog}
+                    onChange={this.openDialog}
+                    floatingLabelText={this.props.labelText}
+                    inputStyle={{ cursor: 'pointer' }}
+                />
+                <div style={styles.openInNew} className="material-icons" onClick={this.openDialog}>open_in_new</div>
+            </div>
+        );
+    }
+
+    render() {
+        const {
+            onFocus,
+            onBlur,
+            labelText,
+            modelDefinition,
+            models,
+            referenceType,
+            referenceProperty,
+            isInteger,
+            translateOptions,
+            isRequired,
+            options,
+            model,
+            limit,
+            fullWidth,
+            top,
+            translateLabel,
+            style,
+            ...other
+        } = this.props;
+
+        return (
+            this.state.options.length > limit
+                ? this.renderDialogDropDown(other)
+                : this.renderSelectField(other)
+        );
+    }
 }
 
 Dropdown.propTypes = {
-    defaultValue: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number,
-        React.PropTypes.bool,
-    ]),
     onFocus: React.PropTypes.func,
     onBlur: React.PropTypes.func,
+    onChange: React.PropTypes.func,
     options: React.PropTypes.array.isRequired,
-    isRequired: React.PropTypes.bool,
-    labelText: React.PropTypes.string.isRequired,
+    fullWidth: React.PropTypes.bool,
     translateOptions: React.PropTypes.bool,
+    isRequired: React.PropTypes.bool,
     limit: React.PropTypes.number,
+    labelText: React.PropTypes.string.isRequired,
+    top: React.PropTypes.any,
 };
 Dropdown.defaultProps = {
     limit: 50,
+    translateOptions: false,
+    isRequired: false,
+    fullWidth: false,
+    top: undefined,
 };
 Dropdown.contextTypes = {
     d2: React.PropTypes.any,

--- a/src/forms/form-fields/drop-down.js
+++ b/src/forms/form-fields/drop-down.js
@@ -223,6 +223,7 @@ Dropdown.propTypes = {
     limit: React.PropTypes.number,
     labelText: React.PropTypes.string.isRequired,
     top: React.PropTypes.any,
+    style: React.PropTypes.any,
 };
 Dropdown.defaultProps = {
     limit: 50,
@@ -230,6 +231,7 @@ Dropdown.defaultProps = {
     isRequired: false,
     fullWidth: false,
     top: undefined,
+    style: undefined,
 };
 Dropdown.contextTypes = {
     d2: React.PropTypes.any,

--- a/src/forms/form-fields/multi-select.js
+++ b/src/forms/form-fields/multi-select.js
@@ -62,7 +62,8 @@ multiSelectActions.removeItemsFromModelCollection
     });
 
 function isOrganisationUnitLevelReference(referenceProperty, modelDefinition) {
-   return ['dataElement.aggregationLevels', 'validationRule.organisationUnitLevels'].indexOf(`${modelDefinition.name}.${referenceProperty}`) > -1;
+    return ['dataElement.aggregationLevels', 'validationRule.organisationUnitLevels']
+        .indexOf(`${modelDefinition.name}.${referenceProperty}`) > -1;
 }
 
 // TODO: Refactor to es2015 class
@@ -166,7 +167,7 @@ export default React.createClass({
             labelWrap: {
                 display: 'flex',
                 marginTop: 24,
-                height: 36
+                height: 36,
             },
             fieldWrap: {
                 position: 'relative',
@@ -174,7 +175,7 @@ export default React.createClass({
         };
 
         return (
-            <div style={styles.fieldWrap}>
+            <div style={{ ...styles.fieldWrap, ...this.props.style }}>
                 {this.state.isRefreshing ? <RefreshMask /> : null }
                 <div style={styles.labelWrap}>
                     <label style={styles.labelStyle}>{this.props.labelText || ''}</label>

--- a/src/forms/form-fields/period-type-drop-down.js
+++ b/src/forms/form-fields/period-type-drop-down.js
@@ -21,7 +21,11 @@ class PeriodTypeDropDown extends React.Component {
     }
 
     render() {
-        return <DropDown {...this.props} options={this.state.options} />;
+        return (
+            <div style={this.props.style}>
+                <DropDown {...this.props} options={this.state.options} />
+            </div>
+        );
     }
 }
 

--- a/src/forms/form-fields/text-editor-field.js
+++ b/src/forms/form-fields/text-editor-field.js
@@ -93,9 +93,9 @@ TextEditorField.propTypes = {
 TextEditorField.contextTypes = {
     d2: React.PropTypes.any,
 };
-// value should be empty string
+
 TextEditorField.defaultProps = {
-    value: null,
+    value: '',
     disabled: false,
     onChange: null,
 };

--- a/src/forms/form-fields/text-editor-field.js
+++ b/src/forms/form-fields/text-editor-field.js
@@ -93,7 +93,7 @@ TextEditorField.propTypes = {
 TextEditorField.contextTypes = {
     d2: React.PropTypes.any,
 };
-
+// value should be empty string
 TextEditorField.defaultProps = {
     value: null,
     disabled: false,

--- a/src/forms/form-fields/text-field.js
+++ b/src/forms/form-fields/text-field.js
@@ -69,26 +69,34 @@ export default class TextFormField extends Component {
             label,
             labelText,
             multiLine,
+            style,
             ...rest
         } = this.props;
 
         const restProps = TextFormField.getWantedProperties(rest);
 
-        const errorStyle = {
-            lineHeight: multiLine ? '48px' : '12px',
-            marginTop: multiLine ? -16 : -12,
+        const styles = {
+            errorStyle: {
+                lineHeight: multiLine ? '48px' : '12px',
+                marginTop: multiLine ? -16 : -12,
+            },
+            fieldWrap: {
+                position: 'relative',
+            },
         };
 
         return (
-            <TextField
-                errorStyle={errorStyle}
-                label={label}
-                multiLine={multiLine}
-                {...restProps}
-                value={this.state.fieldValue}
-                floatingLabelText={labelText}
-                onChange={this.onValueChanged}
-            />
+            <div style={{ ...styles.fieldWrap, ...style }}>
+                <TextField
+                    errorStyle={styles.errorStyle}
+                    label={label}
+                    multiLine={multiLine}
+                    {...restProps}
+                    value={this.state.fieldValue}
+                    floatingLabelText={labelText}
+                    onChange={this.onValueChanged}
+                />
+            </div>
         );
     }
 }
@@ -100,10 +108,12 @@ TextFormField.propTypes = {
     labelText: React.PropTypes.string.isRequired,
     onChange: React.PropTypes.func,
     multiLine: React.PropTypes.bool,
+    style: React.PropTypes.any,
 };
 
 TextFormField.defaultProps = {
     name: '',
+    style: undefined,
     value: null,
     label: '',
     onChange: () => {},


### PR DESCRIPTION
Fix for the stepper that would ignore HIDE_FIELD/SHOW_FIELD rules with config/field-config/field-groups.js.

Since the field rules in EditModel/form-rules/index.js uses the same way to hide and show
fields with the HIDE_FIELD and SHOW_FIELD rule, this causes the rule not work using 
the stepper. 

The EditModel used two ways to hide a field. One involved setting the style to 'display: none' to hide fields that receives style from props. The second was using the same as rules by saving the component into the "hiddenComponent" property and then deleting the content of "component".
      
Now rules uses the second method and EditModel->stepper using the display: none method. 

For fields to hide properly with the stepper, they therefore need to receive styles in props.