### PR TITLE
Adds a analyticsPeriodBoundaries component for program indicators

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "prop-types": "^15.6.0",
     "react-redux": "^5.0.3",
     "react-sortable-hoc": "^0.6.1",
-    "react-speed-dial": "^0.4.6",
+    "react-speed-dial": "^0.4.7",
     "react-test-renderer": "15",
     "redux": "^3.6.0",
     "redux-observable": "^0.14.1",

--- a/src/EditModel/program-indicator/epics.js
+++ b/src/EditModel/program-indicator/epics.js
@@ -24,7 +24,7 @@ function loadProgramIndicator(programIndicatorId) {
         getInstance()
             .then((d2) => {
                 if (programIndicatorId === 'add') {
-                    return d2.models.programIndicator.create();
+                    return d2.models.programIndicator.create({ analyticsPeriodBoundaries: [] });
                 }
                 return d2.models.programIndicator.get(programIndicatorId, requestParams.get('programIndicator'));
             })

--- a/src/config/field-config/field-order.js
+++ b/src/config/field-config/field-order.js
@@ -306,6 +306,7 @@ const fieldOrderByName = new Map([
         'decimals',
         'aggregationType',
         'analyticsType',
+        'analyticsPeriodBoundaries',
         'displayInForm',
         'legendSets',
         'aggregateExportCategoryOptionCombo',

--- a/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
+++ b/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
@@ -102,7 +102,6 @@ function AnalyticsPeriodBoundary (props) {
             />
 
             <RaisedButton
-                style={ { top: '-24px', position: 'relative' } }
                 label="Remove"
                 onClick={e => props.onClick(e)}/>
         </div>
@@ -160,7 +159,7 @@ function AnalyticsPeriodBoundaryList ({ d2, model, onChange }) {
                 <h3 style={ {color: 'rgba(0,0,0,0.5)', fontWeight: 'normal', fontSize: '16px'} }>Analytics period boundaries</h3>
                 <div style={cssStyles}>
                     <div>{boundaries}</div>
-                    <div>
+                    <div style={ { marginTop: '14px' } }>
                         <RaisedButton
                             secondary
                             onClick={addSubField.bind(this, model, onChange)}

--- a/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
+++ b/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
@@ -132,8 +132,7 @@ function addSubField(model, onChange) {
         analyticsPeriodBoundaryType: '',
         boundaryTarget: '',
         offsetNumberOfPeriods: 0,
-        offsetPeriodType: '',
-        programIndicator: model.id
+        offsetPeriodType: ''
     };
 
     return onChange({ target: {

--- a/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
+++ b/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
@@ -2,13 +2,16 @@ import React, { PropTypes } from 'react';
 import { equals, compose } from 'lodash/fp';
 import withState from 'recompose/withState';
 import getContext from 'recompose/getContext';
-import { getInstance } from 'd2/lib/d2';
 import lifecycle from 'recompose/lifecycle';
+
+import { getInstance } from 'd2/lib/d2';
+
+import RaisedButton from 'material-ui/RaisedButton/RaisedButton';
+import FontIcon from 'material-ui/FontIcon/FontIcon';
 
 import DropDown from '../../../forms/form-fields/drop-down';
 import TextField from '../../../forms/form-fields/text-field';
 import PeriodTypeDropDown from '../../../forms/form-fields/period-type-drop-down';
-
 
 // definitions mapped to java enum
 // https://github.com/dhis2/dhis2-core/blob/markus-program-indicators-cohorts/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/AnalyticsPeriodBoundaryType.java#L37-L40
@@ -32,43 +35,76 @@ const periodBoundaryTypes = [
 ];
 
 const boundaryTargets = [
-    {text: 'Incident date', value: 'INCIDENT_DATE'},
-    {text: 'Event date', value: 'EVENT_DATE'},
-    {text: 'Enrollment date', value: 'ENROLLMENT_DATE'}
+    {
+        text: 'Incident date',
+        value: 'INCIDENT_DATE'
+    },
+    {
+        text: 'Event date',
+        value: 'EVENT_DATE'
+    },
+    {
+        text: 'Enrollment date',
+        value: 'ENROLLMENT_DATE'
+    }
 ];
 
 
+// just wrap the component in a span with some margins as they are
+// inline in this form
+const withStyle = function withStyle(BaseField, styles) {
+    return props => (
+        <span style={styles}>
+            <BaseField {...props}/>
+        </span>
+    );
+};
+
 function AnalyticsPeriodBoundary (props) {
-    console.dir(props)
+    const style = {
+        marginRight: '14px'
+    }
+
+    const DD = withStyle(DropDown, style);
+    const TF = withStyle(TextField, style);
+    const PTDD = withStyle(PeriodTypeDropDown, style);
+
     return (
         <div>
-            <DropDown
+            <DD
+                style={ {marginRight: '14px'} }
                 labelText="Boundary target"
                 options={boundaryTargets}
                 onChange={e => props.onChange(e, "boundaryTarget")}
                 value={props.boundaryTarget}
             />
 
-            <DropDown
+            <DD
                 labelText="Analytics period boundary type"
+                style={ {position: 'relative', marginRight: '14px'} }
                 options={periodBoundaryTypes}
                 onChange={e => props.onChange(e, "analyticsPeriodBoundaryType")}
                 value={props.analyticsPeriodBoundaryType}
             />
 
-            <TextField type="number"
+            <TF type="number"
+                style={ { top: '-14px', width: '128px' } }
                 labelText="offset"
                 value={props.offsetNumberOfPeriods}
                 onChange={e => props.onChange(e, "offsetNumberOfPeriods")}
             />
 
-            <PeriodTypeDropDown
+            <PTDD
                 labelText="period"
                 onChange={e => props.onChange(e, "offsetPeriodType")}
+                style={ { marginRight: '14px' } }
                 value={props.offsetPeriodType}
             />
 
-            <button onClick={e => props.onClick(e)}>Delete</button>
+            <RaisedButton
+                style={ { top: '-24px', position: 'relative' } }
+                label="Remove"
+                onClick={e => props.onClick(e)}/>
         </div>
     );
 }
@@ -107,7 +143,11 @@ function addSubField(model, onChange) {
 }
 
 function AnalyticsPeriodBoundaryList ({ d2, model, onChange }) {
-    let boundaries = model.analyticsPeriodBoundaries.map((props, i) => (
+    const cssStyles = {
+        marginLeft: '14px'
+    };
+
+    const boundaries = model.analyticsPeriodBoundaries.map((props, i) => (
         <AnalyticsPeriodBoundary
             key={i}
             onChange={updateSubField.bind(this, props, model, onChange, i)}
@@ -117,11 +157,16 @@ function AnalyticsPeriodBoundaryList ({ d2, model, onChange }) {
     ));
 
     return (<div>
-                <div>{boundaries}</div>
-                <div>
-                    <button onClick={addSubField.bind(this, model, onChange)}>
-                        Add new boundary
-                    </button>
+                <h3 style={ {color: 'rgba(0,0,0,0.5)', fontWeight: 'normal', fontSize: '16px'} }>Analytics period boundaries</h3>
+                <div style={cssStyles}>
+                    <div>{boundaries}</div>
+                    <div>
+                        <RaisedButton
+                            secondary
+                            onClick={addSubField.bind(this, model, onChange)}
+                            label="Add new boundary"
+                            />
+                    </div>
                 </div>
             </div>);
 }

--- a/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
+++ b/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
@@ -23,6 +23,14 @@ const withStyle = function withStyle(BaseField, styles) {
     );
 };
 
+const style = {
+    marginRight: '14px'
+};
+
+const StyledDropDown = withStyle(DropDown, style);
+const StyledTextField = withStyle(TextField, style);
+const StyledPeriodTypeDropDown = withStyle(PeriodTypeDropDown, style);
+
 const boundaryTargets = [
     {
         text: 'boundary_target_incident_date',
@@ -61,16 +69,7 @@ const boundaryTypes =[
 // dhis2-core/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/AnalyticsPeriodBoundaryType.java#L37-L40
 // as they are not exposed over the API
 function AnalyticsPeriodBoundary (props) {
-    const style = {
-        marginRight: '14px'
-    }
-
     const getTranslation = props.d2.i18n.getTranslation.bind(props.d2.i18n);
-
-    const DD = withStyle(DropDown, style);
-    const TF = withStyle(TextField, style);
-    const PTDD = withStyle(PeriodTypeDropDown, style);
-
     return (
         <div style={{
                 display: 'flex',
@@ -78,7 +77,7 @@ function AnalyticsPeriodBoundary (props) {
                 justifyContent: '',
                 alignItems: 'center'
         }}>
-            <DD
+            <StyledDropDown
                 style={ {marginRight: '14px'} }
                 labelText={getTranslation('analytics_boundary_target')}
                 translateOptions={true}
@@ -87,7 +86,7 @@ function AnalyticsPeriodBoundary (props) {
                 value={props.boundaryTarget}
             />
 
-            <DD
+            <StyledDropDown
                 labelText={getTranslation('analytics_period_boundary_type')}
                 style={ {position: 'relative', marginRight: '14px'} }
                 translateOptions={true}
@@ -96,14 +95,14 @@ function AnalyticsPeriodBoundary (props) {
                 value={props.analyticsPeriodBoundaryType}
             />
 
-            <TF type="number"
+            <StyledTextField type="number"
                 style={ { flex: '0 1 auto' } }
                 labelText={getTranslation('period_number_offset')}
                 value={props.offsetNumberOfPeriods}
                 onChange={e => props.onChange(e, "offsetNumberOfPeriods")}
             />
 
-            <PTDD
+            <StyledPeriodTypeDropDown
                 labelText={getTranslation('period_offset')}
                 onChange={e => props.onChange(e, "offsetPeriodType")}
                 style={ { marginRight: '14px' } }

--- a/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
+++ b/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
@@ -23,6 +23,40 @@ const withStyle = function withStyle(BaseField, styles) {
     );
 };
 
+const boundaryTargets = [
+    {
+        text: 'boundary_target_incident_date',
+        value: 'INCIDENT_DATE'
+    },
+    {
+        text: 'boundary_target_event_date',
+        value: 'EVENT_DATE'
+    },
+    {
+        text: 'boundary_target_enrollment_date',
+        value: 'ENROLLMENT_DATE'
+    }
+];
+
+const boundaryTypes =[
+    {
+        text: 'report_period_before_start',
+        value: 'BEFORE_START_OF_REPORTING_PERIOD'
+    },
+    {
+        text: 'report_period_before_end',
+        value: 'BEFORE_END_OF_REPORTING_PERIOD'
+    },
+    {
+        text: 'report_period_after_start',
+        value: 'AFTER_START_OF_REPORTING_PERIOD'
+    },
+    {
+        text: 'report_period_after_end',
+        value: 'AFTER_END_OF_REPORTING_PERIOD'
+    }
+];
+
 // boundary type definitions mapped to java enum
 // dhis2-core/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/AnalyticsPeriodBoundaryType.java#L37-L40
 // as they are not exposed over the API
@@ -47,20 +81,8 @@ function AnalyticsPeriodBoundary (props) {
             <DD
                 style={ {marginRight: '14px'} }
                 labelText={getTranslation('analytics_boundary_target')}
-                options={[
-                    {
-                        text: getTranslation('boundary_target_incident_date'),
-                        value: 'INCIDENT_DATE'
-                    },
-                    {
-                        text: getTranslation('boundary_target_event_date'),
-                        value: 'EVENT_DATE'
-                    },
-                    {
-                        text: getTranslation('boundary_target_enrollment_date'),
-                        value: 'ENROLLMENT_DATE'
-                    }
-                ]}
+                translateOptions={true}
+                options={boundaryTargets}
                 onChange={e => props.onChange(e, "boundaryTarget")}
                 value={props.boundaryTarget}
             />
@@ -68,24 +90,8 @@ function AnalyticsPeriodBoundary (props) {
             <DD
                 labelText={getTranslation('analytics_period_boundary_type')}
                 style={ {position: 'relative', marginRight: '14px'} }
-                options={[
-                    {
-                        text: getTranslation('report_period_before_start'),
-                        value: 'BEFORE_START_OF_REPORTING_PERIOD'
-                    },
-                    {
-                        text: getTranslation('report_period_before_end'),
-                        value: 'BEFORE_END_OF_REPORTING_PERIOD'
-                    },
-                    {
-                        text: getTranslation('report_period_after_start'),
-                        value: 'AFTER_START_OF_REPORTING_PERIOD'
-                    },
-                    {
-                        text: getTranslation('report_period_after_end'),
-                        value: 'AFTER_END_OF_REPORTING_PERIOD'
-                    }
-                ]}
+                translateOptions={true}
+                options={boundaryTypes}
                 onChange={e => props.onChange(e, "analyticsPeriodBoundaryType")}
                 value={props.analyticsPeriodBoundaryType}
             />

--- a/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
+++ b/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
@@ -13,43 +13,6 @@ import DropDown from '../../../forms/form-fields/drop-down';
 import TextField from '../../../forms/form-fields/text-field';
 import PeriodTypeDropDown from '../../../forms/form-fields/period-type-drop-down';
 
-// definitions mapped to java enum
-// https://github.com/dhis2/dhis2-core/blob/markus-program-indicators-cohorts/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/AnalyticsPeriodBoundaryType.java#L37-L40
-const periodBoundaryTypes = [
-    {
-        text: 'Before start of reporting period',
-        value: 'BEFORE_START_OF_REPORTING_PERIOD'
-    },
-    {
-        text: 'Before end of reporting period',
-        value: 'BEFORE_END_OF_REPORTING_PERIOD'
-    },
-    {
-        text: 'After start of reporting period',
-        value: 'AFTER_START_OF_REPORTING_PERIOD'
-    },
-    {
-        text: 'After end of reporting period',
-        value: 'AFTER_END_OF_REPORTING_PERIOD'
-    }
-];
-
-const boundaryTargets = [
-    {
-        text: 'Incident date',
-        value: 'INCIDENT_DATE'
-    },
-    {
-        text: 'Event date',
-        value: 'EVENT_DATE'
-    },
-    {
-        text: 'Enrollment date',
-        value: 'ENROLLMENT_DATE'
-    }
-];
-
-
 // just wrap the component in a span with some margins as they are
 // inline in this form
 const withStyle = function withStyle(BaseField, styles) {
@@ -60,50 +23,92 @@ const withStyle = function withStyle(BaseField, styles) {
     );
 };
 
+// boundary type definitions mapped to java enum
+// dhis2-core/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/AnalyticsPeriodBoundaryType.java#L37-L40
+// as they are not exposed over the API
 function AnalyticsPeriodBoundary (props) {
     const style = {
         marginRight: '14px'
     }
+
+    const getTranslation = props.d2.i18n.getTranslation.bind(props.d2.i18n);
 
     const DD = withStyle(DropDown, style);
     const TF = withStyle(TextField, style);
     const PTDD = withStyle(PeriodTypeDropDown, style);
 
     return (
-        <div>
+        <div style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                justifyContent: '',
+                alignItems: 'center'
+        }}>
             <DD
                 style={ {marginRight: '14px'} }
-                labelText="Boundary target"
-                options={boundaryTargets}
+                labelText={getTranslation('analytics_boundary_target')}
+                options={[
+                    {
+                        text: getTranslation('boundary_target_incident_date'),
+                        value: 'INCIDENT_DATE'
+                    },
+                    {
+                        text: getTranslation('boundary_target_event_date'),
+                        value: 'EVENT_DATE'
+                    },
+                    {
+                        text: getTranslation('boundary_target_enrollment_date'),
+                        value: 'ENROLLMENT_DATE'
+                    }
+                ]}
                 onChange={e => props.onChange(e, "boundaryTarget")}
                 value={props.boundaryTarget}
             />
 
             <DD
-                labelText="Analytics period boundary type"
+                labelText={getTranslation('analytics_period_boundary_type')}
                 style={ {position: 'relative', marginRight: '14px'} }
-                options={periodBoundaryTypes}
+                options={[
+                    {
+                        text: getTranslation('report_period_before_start'),
+                        value: 'BEFORE_START_OF_REPORTING_PERIOD'
+                    },
+                    {
+                        text: getTranslation('report_period_before_end'),
+                        value: 'BEFORE_END_OF_REPORTING_PERIOD'
+                    },
+                    {
+                        text: getTranslation('report_period_after_start'),
+                        value: 'AFTER_START_OF_REPORTING_PERIOD'
+                    },
+                    {
+                        text: getTranslation('report_period_after_end'),
+                        value: 'AFTER_END_OF_REPORTING_PERIOD'
+                    }
+                ]}
                 onChange={e => props.onChange(e, "analyticsPeriodBoundaryType")}
                 value={props.analyticsPeriodBoundaryType}
             />
 
             <TF type="number"
-                style={ { top: '-14px', width: '128px' } }
-                labelText="offset"
+                style={ { flex: '0 1 auto' } }
+                labelText={getTranslation('period_number_offset')}
                 value={props.offsetNumberOfPeriods}
                 onChange={e => props.onChange(e, "offsetNumberOfPeriods")}
             />
 
             <PTDD
-                labelText="period"
+                labelText={getTranslation('period_offset')}
                 onChange={e => props.onChange(e, "offsetPeriodType")}
                 style={ { marginRight: '14px' } }
                 value={props.offsetPeriodType}
             />
 
-            <RaisedButton
-                label="Remove"
-                onClick={e => props.onClick(e)}/>
+            <div style={{ flex: '0 1 auto' }}>
+                <RaisedButton
+                    label={getTranslation('remove_singular')}
+                    onClick={e => props.onClick(e)}/>
+            </div>
         </div>
     );
 }
@@ -141,13 +146,12 @@ function addSubField(model, onChange) {
 }
 
 function AnalyticsPeriodBoundaryList ({ d2, model, onChange }) {
-    const cssStyles = {
-        marginLeft: '14px'
-    };
+    const getTranslation = d2.i18n.getTranslation.bind(d2.i18n);
 
     const boundaries = model.analyticsPeriodBoundaries.map((props, i) => (
         <AnalyticsPeriodBoundary
             key={i}
+            d2={d2}
             onChange={updateSubField.bind(this, props, model, onChange, i)}
             onClick={removeSubField.bind(this, model, onChange, i)}
             {...props}
@@ -155,14 +159,16 @@ function AnalyticsPeriodBoundaryList ({ d2, model, onChange }) {
     ));
 
     return (<div>
-                <h3 style={ {color: 'rgba(0,0,0,0.5)', fontWeight: 'normal', fontSize: '16px'} }>Analytics period boundaries</h3>
-                <div style={cssStyles}>
+                <h3 style={ {color: 'rgba(0,0,0,0.5)', fontWeight: 'normal', fontSize: '16px'} }>
+                    {getTranslation('analytics_period_boundaries')}
+                </h3>
+                <div>
                     <div>{boundaries}</div>
                     <div style={ { marginTop: '14px' } }>
                         <RaisedButton
                             secondary
                             onClick={addSubField.bind(this, model, onChange)}
-                            label="Add new boundary"
+                            label={getTranslation('add_period_boundary')}
                             />
                     </div>
                 </div>

--- a/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
+++ b/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
@@ -2,15 +2,25 @@ import DropDown from '../../../forms/form-fields/drop-down';
 import TextField from '../../../forms/form-fields/text-field';
 import PeriodTypeDropDown from '../../../forms/form-fields/period-type-drop-down';
 
-const periods = [
-    {text: 'years', value: 'Yearly'},
-    {text: 'days', value: 'Daily'},
-    {text: 'months', value: 'Monthly'}
-];
-
+// definitions mapped to java enum
+// https://github.com/dhis2/dhis2-core/blob/markus-program-indicators-cohorts/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/AnalyticsPeriodBoundaryType.java#L37-L40
 const periodBoundaryTypes = [
-    {text: 'Before end of reporting period', value: 'BEFORE_END_OF_REPORTING_PERIOD'},
-    {text: 'After start of reporting period', value: 'AFTER_START_OF_REPORTING_PERIOD'}
+    {
+        text: 'Before start of reporting period',
+        value: 'BEFORE_START_OF_REPORTING_PERIOD'
+    },
+    {
+        text: 'Before end of reporting period',
+        value: 'BEFORE_END_OF_REPORTING_PERIOD'
+    },
+    {
+        text: 'After start of reporting period',
+        value: 'AFTER_END_OF_REPORTING_PERIOD'
+    },
+    {
+        text: 'After end of reporting period',
+        value: 'AFTER_END_OF_REPORTING_PERIOD'
+    }
 ];
 
 const boundaryTarget = [

--- a/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
+++ b/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
@@ -1,5 +1,6 @@
 import DropDown from '../../../forms/form-fields/drop-down';
 import TextField from '../../../forms/form-fields/text-field';
+import PeriodTypeDropDown from '../../../forms/form-fields/period-type-drop-down';
 
 const periods = [
     {text: 'years', value: 'Yearly'},
@@ -7,14 +8,15 @@ const periods = [
     {text: 'months', value: 'Monthly'}
 ];
 
-const boundaries = [
+const periodBoundaryTypes = [
     {text: 'Before end of reporting period', value: 'BEFORE_END_OF_REPORTING_PERIOD'},
     {text: 'After start of reporting period', value: 'AFTER_START_OF_REPORTING_PERIOD'}
 ];
 
-const reports = [
+const boundaryTarget = [
     {text: 'Incident date', value: 'INCIDENT_DATE'},
-    {text: 'Event data', value: 'EVENT_EXECUTION_DATE'}
+    {text: 'Event date', value: 'EVENT_DATE'},
+    {text: 'Enrollment date', value: 'ENROLLMENT_DATE'}
 ];
 
 function onChange (e) {
@@ -26,27 +28,30 @@ function AnalyticsPeriodBoundary (props) {
     return (
         <div>
             <DropDown
-                labelText="report"
-                options={reports}
+                labelText="Boundary target"
+                options={boundaryTarget}
                 onChange={onChange}
-                value={props.boundaryTarget} />
+                value={props.boundaryTarget}
+            />
 
             <DropDown
-                labelText="boundary"
-                options={boundaries}
+                labelText="Analytics period boundary type"
+                options={periodBoundaryTypes}
                 onChange={onChange}
-                value={props.analyticsPeriodBoundaryType} />
+                value={props.analyticsPeriodBoundaryType}
+            />
 
             <TextField type="number"
                 labelText="offset"
                 value={props.offsetNumberOfPeriods}
-                onChange={onChange} />
-
-            <DropDown
-                labelText="period"
-                options={periods}
                 onChange={onChange}
-                value={props.offsetPeriodType}/>
+            />
+
+            <PeriodTypeDropDown
+                labelText="period"
+                onChange={onChange}
+                value={props.offsetPeriodType}
+            />
 
             <button>Delete</button>
         </div>

--- a/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
+++ b/src/config/field-overrides/program-indicator/AnalyticsPeriodBoundaries.js
@@ -1,0 +1,62 @@
+import DropDown from '../../../forms/form-fields/drop-down';
+import TextField from '../../../forms/form-fields/text-field';
+
+const periods = [
+    {text: 'years', value: 'Yearly'},
+    {text: 'days', value: 'Daily'},
+    {text: 'months', value: 'Monthly'}
+];
+
+const boundaries = [
+    {text: 'Before end of reporting period', value: 'BEFORE_END_OF_REPORTING_PERIOD'},
+    {text: 'After start of reporting period', value: 'AFTER_START_OF_REPORTING_PERIOD'}
+];
+
+const reports = [
+    {text: 'Incident date', value: 'INCIDENT_DATE'},
+    {text: 'Event data', value: 'EVENT_EXECUTION_DATE'}
+];
+
+function onChange (e) {
+    console.log('onChange', e);
+}
+
+function AnalyticsPeriodBoundary (props) {
+    console.dir(props)
+    return (
+        <div>
+            <DropDown
+                labelText="report"
+                options={reports}
+                onChange={onChange}
+                value={props.boundaryTarget} />
+
+            <DropDown
+                labelText="boundary"
+                options={boundaries}
+                onChange={onChange}
+                value={props.analyticsPeriodBoundaryType} />
+
+            <TextField type="number"
+                labelText="offset"
+                value={props.offsetNumberOfPeriods}
+                onChange={onChange} />
+
+            <DropDown
+                labelText="period"
+                options={periods}
+                onChange={onChange}
+                value={props.offsetPeriodType}/>
+
+            <button>Delete</button>
+        </div>
+    );
+}
+
+export function AnalyticsPeriodBoundaries (props) {
+    console.log(props.model.analyticsPeriodBoundaries);
+    let boundaries = props.model.analyticsPeriodBoundaries.map(AnalyticsPeriodBoundary);
+    return (
+        <div>{boundaries}</div>
+    );
+}

--- a/src/config/field-overrides/programIndicator.js
+++ b/src/config/field-overrides/programIndicator.js
@@ -21,6 +21,7 @@ import ExpressionStatusIcon, {
     getColorForExpressionStatus,
     getBackgroundColorForExpressionStatus } from './program-indicator/ExpressionStatusIcon';
 import OperatorButtons from '../../EditModel/OperatorButtons.component';
+import { AnalyticsPeriodBoundaries } from './program-indicator/AnalyticsPeriodBoundaries';
 
 const styles = {
     programIndicatorExpression: {
@@ -263,7 +264,10 @@ const enhance = compose(
 );
 
 export default new Map([
-    decimals,
+    [ 'analyticsPeriodBoundaries', {
+        component: AnalyticsPeriodBoundaries
+    }],
+
     ['expression', {
         component: enhance(ProgramIndicatorExpression),
     }],
@@ -271,4 +275,6 @@ export default new Map([
     ['filter', {
         component: enhance(ProgramIndicatorExpression),
     }],
+
+    decimals,
 ]);

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -1983,3 +1983,5 @@ due_date_label=Description of due date
 min_days_from_start=Scheduled days from start
 pre_generate_uid=Pre-generate event UID
 standard_interval=Standard interval days
+
+analytics_period_boundaries=Analytics period boundaries

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -1985,3 +1985,18 @@ pre_generate_uid=Pre-generate event UID
 standard_interval=Standard interval days
 
 analytics_period_boundaries=Analytics period boundaries
+analytics_period_boundary_type=Analytics period boundary type
+analytics_boundary_target=Boundary target
+remove_singular=Remove
+add_period_boundary=Add new boundary
+period_number_offset=Offset period by amount
+period_offset=Period type
+
+report_period_before_start=Before start of reporting period
+report_period_before_end=Before end of reporting period
+report_period_after_start=After start of reporting period
+report_period_after_end=After end of reporting period
+
+boundary_target_incident_date=Incident date
+boundary_target_event_date=Event date
+boundary_target_enrollment_date=Enrollment date

--- a/yarn.lock
+++ b/yarn.lock
@@ -5802,9 +5802,9 @@ react-sortable-hoc@^0.6.1:
     lodash "^4.12.0"
     prop-types "^15.5.7"
 
-react-speed-dial@^0.4.6:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/react-speed-dial/-/react-speed-dial-0.4.6.tgz#ecded28a737b62a689f799f6b9d1709d7d4f758e"
+react-speed-dial@^0.4.7:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/react-speed-dial/-/react-speed-dial-0.4.7.tgz#7d26bfa8973c0fa7db2a6e29cd46e8c61a36497e"
 
 react-tap-event-plugin@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Related to https://jira.dhis2.org/browse/DHIS2-2496

_N.B. This depends on the extended datamodel targeted for 2.29, I will tag 2.28 in maintenance-app before merging this._

Some notes:

1. I could not figure out how to get the potential values for the enums from the API (I was told that it was not possible) so resorted to hardcoding them for `boundaryTarget` and `boundaryType`. I saw this technique being used elsewhere, e.g. `programRuleActionDialog.component.js`.

2. Updating subfield (add/remove/change value for nested dropdowns) need to be handled by shortcircuiting the `onChange` handler from the parent form builder to avoid the programIndicator model getting reset, effectively throwing away any changes, everytime a subfield was added/removed/updated. The code has to keep track of what fields change and only put them on the model when it's time to hit "save".

3. The form components assume that they are supposed to be laid out in a vertical layout, but the proposed design in DHIS-2496 flips this assumption and wants the elements laid out horisontally, so that's why all the components are wrapped in a HOC with some custom style which fixes margins and layout.