### PR TITLE
Revert "DHIS2-2683 Remove callbacks from the `onEnter` handlers (#381)"

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -16,7 +16,6 @@ import store from './store';
 import { resetActiveStep } from './EditModel/actions';
 import { loadEventProgram } from './EditModel/event-program/actions';
 import { loadProgramIndicator } from './EditModel/program-indicator/actions';
-import { noop } from 'lodash/fp';
 
 import onDemand from './on-demand';
 
@@ -56,10 +55,8 @@ function initStateOuHierarchy() {
     });
 }
 
-// TODO: We could use an Observable that manages the current modelType
-// to load the correct d2.Model. This would clean up the load function
-// below.
-function loadObject({ params }, replace) {
+// TODO: We could use an Observable that manages the current modelType to load the correct d2.Model. This would clean up the load function below.
+function loadObject({ params }, replace, callback) {
     initState({ params });
 
     if (params.modelId === 'add') {
@@ -67,12 +64,10 @@ function loadObject({ params }, replace) {
             const modelToEdit = d2.models[params.modelType].create();
 
             // Set the parent for the new organisationUnit to the selected OU
-            // TODO: Should probably be able to do this in a different
-            // way when this becomes needed for multiple object types
+            // TODO: Should probably be able to do this in a different way when this becomes needed for multiple object types
             if (params.modelType === 'organisationUnit') {
                 return appState
-                    // Just take the first value as we don't want this
-                    // observer to keep updating the state
+                // Just take the first value as we don't want this observer to keep updating the state
                     .take(1)
                     .subscribe((state) => {
                         if (state.selectedOrganisationUnit && state.selectedOrganisationUnit.id) {
@@ -82,6 +77,7 @@ function loadObject({ params }, replace) {
                         }
 
                         modelToEditStore.setState(modelToEdit);
+                        callback();
                     });
             }
 
@@ -96,41 +92,43 @@ function loadObject({ params }, replace) {
                 }, {});
 
             modelToEditStore.setState(Object.assign(modelToEdit, listFilters));
+            return callback();
         });
     } else {
         objectActions.getObjectOfTypeById({ objectType: params.modelType, objectId: params.modelId })
             .subscribe(
-                noop,
+                () => callback(),
                 (errorMessage) => {
                     replace(`/list/${params.modelType}`);
                     snackActions.show({ message: errorMessage, action: 'ok' });
-                },
+                    callback();
+                }
             );
     }
 }
 
-function loadOrgUnitObject({ params }, replace) {
+function loadOrgUnitObject({ params }, replace, callback) {
     loadObject({
         params: {
             modelType: 'organisationUnit',
             groupName: params.groupName,
             modelId: params.modelId,
         },
-    }, replace);
+    }, replace, callback);
 }
 
-function loadOptionSetObject({ params }, replace) {
+function loadOptionSetObject({ params }, replace, callback) {
     loadObject({
         params: {
             modelType: 'optionSet',
             groupName: params.groupName,
             modelId: params.modelId,
         },
-    }, replace);
+    }, replace, callback);
 }
 
 function createLoaderForSchema(schema, actionCreatorForLoadingObject, resetActiveStep) {
-    return ({ location: { query }, params }, replace) => {
+    return ({ location: { query }, params }, replace, callback) => {
         initState({
             params: {
                 modelType: schema,
@@ -141,49 +139,57 @@ function createLoaderForSchema(schema, actionCreatorForLoadingObject, resetActiv
         // Fire load action for the event program program to be edited
         store.dispatch(actionCreatorForLoadingObject({ schema, id: params.modelId, query }));
         store.dispatch(resetActiveStep());
+
+        callback();
     };
 }
 
-function loadList({ params }, replace) {
+function loadList({ params }, replace, callback) {
     if (params.modelType === 'organisationUnit') {
-        // Don't load organisation units as they get loaded through the
-        // appState Also load the initialState without cache so we
-        // refresh the assigned organisation units These could have
-        // changed by adding an organisation unit which would need to be
-        // reflected in the organisation unit tree
+        // Don't load organisation units as they get loaded through the appState
+        // Also load the initialState without cache so we refresh the assigned organisation units
+        // These could have changed by adding an organisation unit which would need to be reflected in the
+        // organisation unit tree
         initState({ params });
+        return callback();
     }
 
     initState({ params });
     return listActions.loadList(params.modelType)
         .take(1)
         .subscribe(
-            noop,
+            (message) => {
+                log.debug(message);
+                callback();
+            },
             (message) => {
                 if (/^.+s$/.test(params.modelType)) {
                     const nonPluralAttempt = params.modelType.substring(0, params.modelType.length - 1);
                     log.warn(`Could not find requested model type '${params.modelType}' attempting to redirect to '${nonPluralAttempt}'`);
                     replace(`list/${nonPluralAttempt}`);
+                    callback();
                 } else {
                     log.error('No clue where', params.modelType, 'comes from... Redirecting to app root');
                     log.error(message);
 
                     replace('/');
+                    callback();
                 }
             },
         );
 }
 
-function cloneObject({ params }, replace) {
+function cloneObject({ params }, replace, callback) {
     initState({ params });
 
     objectActions.getObjectOfTypeByIdAndClone({ objectType: params.modelType, objectId: params.modelId })
         .subscribe(
-            noop,
+            () => callback(),
             (errorMessage) => {
                 replace(`/list/${params.modelType}`);
                 snackActions.show({ message: errorMessage, action: 'ok' });
-            },
+                callback();
+            }
         );
 }
 


### PR DESCRIPTION
This reverts commit 2cac9446a2e62878c91530a2441457d0128cfcd1.

Removing the callback handlers fixed the API getting hit twice, but
caused other, non-trivial issues, so this is getting reverted for now.