### PR TITLE
Fix/data set notification templates should be non sharable

### DIFF
--- a/src/config/field-overrides/data-set-notification-template/DataSetNotificationSubjectAndMessageTemplateFields.js
+++ b/src/config/field-overrides/data-set-notification-template/DataSetNotificationSubjectAndMessageTemplateFields.js
@@ -1,0 +1,25 @@
+import { map } from 'lodash/fp';
+import compose from 'recompose/compose';
+import withProps from 'recompose/withProps';
+import mapProps from 'recompose/mapProps';
+import SubjectAndMessageTemplateFields from '../validation-notification-template/SubjectAndMessageTemplateFields';
+import actions from '../../../EditModel/objectActions';
+
+const DATA_SET_VARIABLES = [
+    'data_set_name',
+    'current_date',
+];
+
+const toVariableType = name => ['V', name];
+
+const DataSetNotificationSubjectAndMessageTemplateFields = compose(
+    withProps({
+        variableTypes: map(toVariableType, DATA_SET_VARIABLES),
+    }),
+    mapProps(props => ({
+        ...props,
+        onUpdate: actions.update,
+    })),
+)(SubjectAndMessageTemplateFields);
+
+export default DataSetNotificationSubjectAndMessageTemplateFields;

--- a/src/config/field-overrides/data-set-notification-template/RecipentUserGroup.js
+++ b/src/config/field-overrides/data-set-notification-template/RecipentUserGroup.js
@@ -1,0 +1,29 @@
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import DropDownAsync from '../../../forms/form-fields/drop-down-async';
+
+const RecipentUserGroup = (props) => {
+    if (!props.model || props.model.notificationRecipient !== 'USER_GROUP') {
+        return null;
+    }
+
+    return (
+        <div style={props.style} >
+            <DropDownAsync {...props} />
+        </div>);
+};
+
+RecipentUserGroup.propTypes = {
+    style: PropTypes.object,
+    model: PropTypes.shape({
+        notificationRecipient: PropTypes.string,
+    }),
+};
+
+RecipentUserGroup.defaultProps = {
+    style: {},
+    model: null,
+};
+
+export default RecipentUserGroup;

--- a/src/config/field-overrides/data-set/DataSetElementList.component.js
+++ b/src/config/field-overrides/data-set/DataSetElementList.component.js
@@ -1,0 +1,120 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Column from 'd2-ui/lib/layout/Column.component';
+import Row from 'd2-ui/lib/layout/Row.component';
+import Translate from 'd2-ui/lib/i18n/Translate.component';
+import MenuItem from 'material-ui/MenuItem/MenuItem';
+import SelectField from 'material-ui/SelectField/SelectField';
+import { map, memoize } from 'lodash/fp';
+import withHandlers from 'recompose/withHandlers';
+
+const getOptions = memoize(categoryCombos => map(({ displayName, id }) => (
+    <MenuItem key={id} primaryText={displayName} value={id} />
+), categoryCombos));
+
+const enhanceCategoryComboSelectField = withHandlers({
+    onChange: ({ categoryCombos = new Map(), onChange }) => (event, index, value) => {
+        onChange(categoryCombos.find(categoryCombo => categoryCombo.id === value));
+    },
+});
+
+const CategoryComboSelectField = enhanceCategoryComboSelectField(
+    ({ categoryCombos, value, onChange }) => {
+        const options = getOptions(categoryCombos);
+
+        return (
+            <SelectField
+                value={value}
+                onChange={onChange}
+                fullWidth
+                floatingLabelText={<Translate>override_data_element_category_combo</Translate>}
+            >
+                {options}
+            </SelectField>
+        );
+    },
+);
+
+const createGetCategoryCombosForSelect = (d2, categoryCombos) => memoize(dataElementCategoryComboId => categoryCombos
+    .reduce((acc, categoryCombo) => {
+        if (categoryCombo.id === dataElementCategoryComboId) {
+            acc.unshift({
+                ...categoryCombo,
+                displayName: d2.i18n.getTranslation('no_override'),
+            });
+            return acc;
+        }
+
+        acc.push(categoryCombo);
+        return acc;
+    }, []));
+function DataSetElementList({ dataSetElements, categoryCombos, onCategoryComboSelected }, { d2 }) {
+    const styles = {
+        elementListItem: {
+            width: '49%',
+        },
+
+        noDataElementMessage: {
+            paddingTop: '2rem',
+        },
+
+        originalCategoryCombo: {
+            color: '#CCC',
+            fontSize: '1rem',
+            fontWeight: '300',
+        },
+    };
+
+    const getCategoryCombosForSelect = createGetCategoryCombosForSelect(d2, categoryCombos);
+
+
+    const dataSetElementsRows = dataSetElements
+        .sort((left, right) => ((left.dataElement ? left.dataElement.displayName : '')
+            .localeCompare(right.dataElement && right.dataElement.displayName)))
+        .map((dataSetElement) => {
+            const { categoryCombo = {}, dataElement = {} } = dataSetElement;
+            const categoryCombosForSelect = getCategoryCombosForSelect(dataElement.categoryCombo.id);
+            const onChange = catCombo => onCategoryComboSelected(dataSetElement, catCombo);
+
+            return (
+                <Row key={dataSetElement.dataElement.id} style={{ alignItems: 'center' }}>
+                    <div style={styles.elementListItem}>
+                        <div>{dataElement.displayName}</div>
+                        <div style={styles.originalCategoryCombo}>{dataElement.categoryCombo.displayName}</div>
+                    </div>
+                    <div style={styles.elementListItem}>
+                        <CategoryComboSelectField
+                            categoryCombos={categoryCombosForSelect}
+                            value={categoryCombo.id}
+                            onChange={onChange}
+                        />
+                    </div>
+                </Row>
+            );
+        });
+
+    if (dataSetElementsRows.length === 0) {
+        return (
+            <div style={styles.noDataElementMessage}>
+                {d2.i18n.getTranslation('select_a_data_element_before_applying_an_override')}
+            </div>
+        );
+    }
+
+    return (
+        <Column>
+            {dataSetElementsRows}
+        </Column>
+    );
+}
+
+DataSetElementList.propTypes = {
+    dataSetElements: PropTypes.array.isRequired,
+    categoryCombos: PropTypes.array.isRequired,
+    onCategoryComboSelected: PropTypes.array.isRequired,
+};
+
+DataSetElementList.contextTypes = {
+    d2: PropTypes.object,
+};

--- a/src/config/field-overrides/dataSetNotificationTemplate.js
+++ b/src/config/field-overrides/dataSetNotificationTemplate.js
@@ -1,32 +1,8 @@
-import React from 'react';
 
-import { map } from 'lodash/fp';
-import withProps from 'recompose/withProps';
-import mapProps from 'recompose/mapProps';
-import compose from 'recompose/compose';
-
-import actions from '../../EditModel/objectActions';
 import DeliveryChannels from './program-notification-template/DeliveryChannels';
 import RelativeScheduledDays from './program-notification-template/RelativeScheduledDays';
-import SubjectAndMessageTemplateFields from './validation-notification-template/SubjectAndMessageTemplateFields';
-import DropDownAsync from '../../forms/form-fields/drop-down-async';
-
-const DATA_SET_VARIABLES = [
-    'data_set_name',
-    'current_date',
-];
-
-const toVariableType = name => ['V', name];
-
-const DataSetNotificationSubjectAndMessageTemplateFields = compose(
-    withProps({
-        variableTypes: map(toVariableType, DATA_SET_VARIABLES),
-    }),
-    mapProps(props => ({
-        ...props,
-        onUpdate: actions.update,
-    })),
-)(SubjectAndMessageTemplateFields);
+import RecipentUserGroup from './data-set-notification-template/RecipentUserGroup';
+import DataSetNotificationSubjectAndMessageTemplateFields from './data-set-notification-template/DataSetNotificationSubjectAndMessageTemplateFields';
 
 export default new Map([
     ['deliveryChannels', {
@@ -48,15 +24,9 @@ export default new Map([
         component: DataSetNotificationSubjectAndMessageTemplateFields,
     }],
     ['notificationRecipient', {
-        required: 'true',
+        required: true,
     }],
     ['recipientUserGroup', {
-        component: (props) => {
-            if (!props.model || props.model.notificationRecipient !== 'USER_GROUP') {
-                return null;
-            }
-
-            return <DropDownAsync {...props} />;
-        },
+        component: RecipentUserGroup,
     }],
 ]);

--- a/src/config/field-overrides/externalMapLayer.js
+++ b/src/config/field-overrides/externalMapLayer.js
@@ -8,7 +8,7 @@ import withD2Context from 'd2-ui/lib/component-helpers/addD2Context';
 
 export default new Map([
     ['imageFormat', {
-        component: withD2Context((props, { d2 }) => props.model.mapService === 'WMS' ?
+        component: withD2Context((props, { d2 }) => (props.model.mapService === 'WMS' ?
             <SubFieldWrap>
                 <DropDown
                     labelText={props.labelText}
@@ -25,7 +25,7 @@ export default new Map([
                     onChange={(e) => { actions.update({ fieldName: 'layers', value: e.target.value }); }}
                     style={{ width: '97.5%' }}
                 />
-            </SubFieldWrap> : null),
+            </SubFieldWrap> : null)),
     }],
     ['url', { validators: [{ validator: isUrl, message: isUrl.message }] }],
     ['legendSetUrl', { validators: [{ validator: isUrl, message: isUrl.message }] }],

--- a/src/config/field-overrides/program.js
+++ b/src/config/field-overrides/program.js
@@ -2,11 +2,11 @@ import PeriodTypeDropDown from '../../forms/form-fields/period-type-drop-down';
 import DropDownAsyncGetter from '../../forms/form-fields/drop-down-async-getter';
 
 async function getRelationshipTypes(model, d2) {
-    if(!model.relationshipType) {
+    if (!model.relationshipType) {
         return [];
     }
     const relationship = await d2.models.relationshipTypes.get(
-        model.relationshipType.id
+        model.relationshipType.id,
     );
     const relationhipOptions = [
         {

--- a/src/config/field-overrides/programNotificationTemplate.js
+++ b/src/config/field-overrides/programNotificationTemplate.js
@@ -1,13 +1,14 @@
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import withProps from 'recompose/withProps';
 import compose from 'recompose/compose';
+import { map } from 'lodash/fp';
+
 import RelativeScheduledDays from './program-notification-template/RelativeScheduledDays';
 import DeliveryChannels from './program-notification-template/DeliveryChannels';
 import DropDownAsync from '../../forms/form-fields/drop-down-async';
 import SubjectAndMessageTemplateFields from './validation-notification-template/SubjectAndMessageTemplateFields';
-import { map } from 'lodash/fp';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { setStageNotificationValue } from '../../EditModel/event-program/notifications/actions';
 
 const PROGRAM_STAGE_VARIABLES = [
@@ -52,7 +53,7 @@ export default new Map([
         },
     }],
     ['notificationRecipient', {
-        required: 'true',
+        required: true,
     }],
     ['recipientUserGroup', {
         component: (props) => {

--- a/src/config/maintenance-models.js
+++ b/src/config/maintenance-models.js
@@ -130,6 +130,9 @@ const typeDetails = {
         filters: ['formType'],
         columns: ['displayName', 'formType', 'periodType', 'publicAccess', 'lastUpdated'],
     },
+    dataSetNotificationTemplate: {
+        columns: ['displayName', 'lastUpdated'],
+    },
     indicator: {
         filters: ['indicatorType'],
         columns: ['displayName', 'indicatorType[displayName]', 'publicAccess', 'lastUpdated'],

--- a/src/forms/form-fields/drop-down.js
+++ b/src/forms/form-fields/drop-down.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import SelectField from 'material-ui/SelectField/SelectField';
 import TextField from 'material-ui/TextField';
 import isString from 'd2-utilizr/lib/isString';
@@ -12,12 +13,8 @@ class Dropdown extends React.Component {
 
         this.getTranslation = context.d2.i18n.getTranslation.bind(context.d2.i18n);
 
-        this._onChange = this._onChange.bind(this);
-        this.openDialog = this.openDialog.bind(this);
-        this.closeDialog = this.closeDialog.bind(this);
-
         this.state = {
-            value: (this.props.value !== undefined && this.props.value !== null) ? this.props.value : '',
+            value: this.props.value,
             options: this.getOptions(this.props.options, this.props.isRequired),
             dialogOpen: false,
         };
@@ -29,7 +26,15 @@ class Dropdown extends React.Component {
         });
     }
 
-    getOptions(options, required = false) {
+    onChange = (event, index, value) => {
+        this.props.onChange({
+            target: {
+                value,
+            },
+        });
+    }
+
+    getOptions(options) {
         const opts = options
             .map(option => ({
                 value: option.value,
@@ -45,47 +50,39 @@ class Dropdown extends React.Component {
             });
     }
 
-    _onChange(event, index, value) {
-        this.props.onChange({
-            target: {
-                value,
-            },
-        });
-    }
+    getOptionText = value => (value && this.state.options.length
+        ? this.state.options.find(option => option.value === value).text
+        : '')
 
-    openDialog() {
-        this.setState({ dialogOpen: true, filterText: '' });
-    }
-
-    closeDialog() {
+    closeDialog = () => {
         this.setState({ dialogOpen: false });
     }
 
-    getOptionText(value) {
-        return value && this.state.options.length
-            ? this.state.options.find(option => option.value === value).text
-            : '';
+    openDialog = () => {
+        this.setState({ dialogOpen: true, filterText: '' });
     }
 
-    renderDialogOption(value, label) {
-        return (
-            <div
-                style={{ cursor: 'pointer', margin: 8 }}
-                key={value}
-                onClick={() => {
-                    this.props.onChange({ target: { value } });
-                    this.setState({ dialogOpen: false, value });
-                }}
-            ><a>{label}</a></div>
-        );
+    textFieldOnChange = (e, value) => {
+        this.setState({ filterText: value });
     }
 
-    renderOptions() {
+    renderDialogOption = (value, label) => (
+        <div
+            style={{ cursor: 'pointer', margin: 8 }}
+            key={value}
+            onClick={() => {
+                this.props.onChange({ target: { value } });
+                this.setState({ dialogOpen: false, value });
+            }}
+        ><a>{label}</a></div>
+    )
+
+    renderOptions = () => {
         const options = this.state.options
-            .map((option, index) => (
+            .map(option => (
                 <MenuItem
                     primaryText={option.text}
-                    key={index}
+                    key={option.value}
                     value={option.value}
                     label={option.text}
                 />
@@ -114,7 +111,7 @@ class Dropdown extends React.Component {
                 value={this.state.value}
                 fullWidth={this.props.fullWidth}
                 {...other}
-                onChange={this._onChange}
+                onChange={this.onChange}
                 floatingLabelText={this.props.labelText}
             >
                 {this.renderOptions()}
@@ -122,15 +119,13 @@ class Dropdown extends React.Component {
         );
     }
 
+
     renderDialogDropDown(other) {
         const styles = {
             fieldStyle: {
                 width: this.props.fullWidth ? '100%' : 'inherit',
                 position: 'relative',
                 top,
-            },
-            textField: {
-                marginBottom: 16,
             },
             openInNew: {
                 position: 'absolute',
@@ -140,6 +135,7 @@ class Dropdown extends React.Component {
                 cursor: 'pointer',
             },
         };
+
 
         return (
             <div style={styles.fieldStyle}>
@@ -155,7 +151,7 @@ class Dropdown extends React.Component {
                 >
                     <TextField
                         floatingLabelText="Filter list"
-                        onChange={(e, value) => { this.setState({ filterText: value }); }}
+                        onChange={this.textFieldOnChange}
                         style={styles.textField}
                     />
                     {!this.props.isRequired && this.renderDialogOption(null, this.getTranslation('no_value'))}
@@ -174,6 +170,7 @@ class Dropdown extends React.Component {
                     value={this.getOptionText(this.state.value)}
                     onClick={this.openDialog}
                     onChange={this.openDialog}
+                    style={styles.textField}
                     floatingLabelText={this.props.labelText}
                     inputStyle={{ cursor: 'pointer' }}
                 />
@@ -205,34 +202,57 @@ class Dropdown extends React.Component {
         } = this.props;
 
         return (
-            this.state.options.length > limit
-                ? this.renderDialogDropDown(other)
-                : this.renderSelectField(other)
+            <div style={{ ...style }}>
+                {this.state.options.length > limit
+                    ? this.renderDialogDropDown(other)
+                    : this.renderSelectField(other)}
+            </div>
         );
     }
 }
 
 Dropdown.propTypes = {
-    onFocus: React.PropTypes.func,
-    onBlur: React.PropTypes.func,
-    onChange: React.PropTypes.func,
-    options: React.PropTypes.array.isRequired,
-    fullWidth: React.PropTypes.bool,
-    translateOptions: React.PropTypes.bool,
-    isRequired: React.PropTypes.bool,
-    limit: React.PropTypes.number,
-    labelText: React.PropTypes.string.isRequired,
-    top: React.PropTypes.any,
-    style: React.PropTypes.any,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
+    onChange: PropTypes.func,
+    fullWidth: PropTypes.bool,
+    translateOptions: PropTypes.bool,
+    isInteger: PropTypes.bool,
+    isRequired: PropTypes.bool,
+    limit: PropTypes.number,
+    top: PropTypes.any,
+    style: PropTypes.any,
+    value: PropTypes.string,
+    labelText: PropTypes.string.isRequired,
+    translateLabel: PropTypes.string,
+    referenceProperty: PropTypes.string,
+    modelDefinition: PropTypes.object,
+    models: PropTypes.object,
+    model: PropTypes.object,
+    referenceType: PropTypes.object,
+    options: PropTypes.array.isRequired,
 };
+
 Dropdown.defaultProps = {
+    onFocus: () => {},
+    onBlur: () => {},
+    onChange: () => {},
     limit: 50,
     translateOptions: false,
     isRequired: false,
     fullWidth: false,
+    isInteger: false,
     top: undefined,
     style: undefined,
+    value: '',
+    translateLabel: '',
+    referenceProperty: '',
+    modelDefinition: {},
+    models: {},
+    model: {},
+    referenceType: {},
 };
+
 Dropdown.contextTypes = {
     d2: React.PropTypes.any,
 };

--- a/src/forms/form-fields/helpers/QuickAddLink.component.js
+++ b/src/forms/form-fields/helpers/QuickAddLink.component.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router';
 import IconButton from 'material-ui/IconButton/IconButton';
 import AddCircleOutlineIcon from 'material-ui/svg-icons/content/add-circle-outline';
 import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
 import { getSectionForType } from '../../../config/maintenance-models';
-import { Link } from 'react-router';
 
 export default function QuickAddLink(props) {
     const { referenceType, onRefreshClick } = props;
@@ -40,3 +41,8 @@ export default function QuickAddLink(props) {
         </div>
     );
 }
+
+QuickAddLink.propTypes = {
+    referenceType: PropTypes.string.isRequired,
+    onRefreshClick: PropTypes.func.isRequired,
+};

--- a/src/forms/form-fields/helpers/RefreshMask.component.js
+++ b/src/forms/form-fields/helpers/RefreshMask.component.js
@@ -25,6 +25,7 @@ export default function RefreshMask({ horizontal }, { d2 }) {
         </div>
     );
 }
-RefreshMask.contextTypes = {
-    d2: PropTypes.object,
-};
+
+RefreshMask.propTypes = { horizontal: PropTypes.bool };
+RefreshMask.defaultProps = { horizontal: false };
+RefreshMask.contextTypes = { d2: PropTypes.object };

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -1128,6 +1128,7 @@ failed_to_delete_section=Failed to delete section
 section_saved=Section saved
 failed_to_save_section=Failed to save section
 confirm_delete_data_set=Are you sure you want to delete this data set?
+confirm_delete_data_set_notification_template=Are you sure you want to delete this data set notification?
 polygon_coordinates_are_not_editable=Polygon coordinates are not editable
 org_unit_assignment=Organisation unit assignment
 no_changes_to_be_saved=No changes to be saved


### PR DESCRIPTION
---Refactoring---
- Refactored out DataSetNotificationSubjectAndMessageTemplateFields and RecipentUserGroup from dataSetNotificationTemplate.js into their own files.
- Refactored out DataSetElementList from DataSetElementField.component.js into its own file.
- Changed drop-down and drop-down-async into ES6 classes.
- Added proptypes to QuickAddLink.component.js and RefreshMask.component.js

----Fixes----
- Made dataSetNotificationTemplate non sharable
- Added translation for confirm_delete_data_set_notification_template
- Fixed hiding of fields by spreading in style from parent into div. (both where DropDown fields)
