### PR TITLE
Use trackedEntityAttribute Id when editing attribute

### DIFF
--- a/src/config/field-overrides/tracked-entity-type/AssignTrackedEntityTypeAttributes.component.js
+++ b/src/config/field-overrides/tracked-entity-type/AssignTrackedEntityTypeAttributes.component.js
@@ -77,7 +77,7 @@ class AssignTrackedEntityTypeAttributes extends Component {
 
     onEditAttribute = (changedAttribute) => {
         const newAssignedAttributes = this.state.assignedAttributes
-            .map(attribute => ((attribute.id === changedAttribute.id)
+            .map(attribute => ((attribute.trackedEntityAttribute.id === changedAttribute.trackedEntityAttribute.id)
                 ? changedAttribute
                 : attribute),
             );


### PR DESCRIPTION
When editing attributes that was recently added (not loaded from server), the objects did not have an id. We therefore use the trackedEntityAttribute id instead. Could also generateUid() on the attributes in componentDidMount() on client, don't know if that is needed.