### PR TITLE
set the components to return when style.display is null instead to hide

### DIFF
--- a/src/forms/form-fields/drop-down-async.js
+++ b/src/forms/form-fields/drop-down-async.js
@@ -6,14 +6,9 @@ import DropDown from './drop-down';
 import QuickAddLink from './helpers/QuickAddLink.component';
 import RefreshMask from './helpers/RefreshMask.component';
 
-const styles = {
-    fieldStyle: {
-        display: 'flex',
-        alignItems: 'flex-end',
-    },
-    fieldWrap: {
-        position: 'relative',
-    },
+const wrapStyles = {
+    display: 'flex',
+    alignItems: 'flex-end',
 };
 
 class DropDownAsync extends Component {
@@ -167,8 +162,16 @@ class DropDownAsync extends Component {
             ...other
         } = this.props;
 
+        /* Because of bad alignment of material ui textfield and selectfield, the compoents becomes skewed when
+            using the hide method EditModelForm.component (setting the display to none/block). The component 
+            must instead chose to either use display:none from style or its defined display:flex. 
+        */
+        if (style && style.display && style.display === 'none') {
+            return null;
+        }
+
         return (
-            <div style={{...styles.fieldStyle, ...style}}>
+            <div style={wrapStyles}>
                     {this.state.isRefreshing && <RefreshMask horizontal />}
                     <DropDown
                         {...other}

--- a/src/forms/form-fields/drop-down.js
+++ b/src/forms/form-fields/drop-down.js
@@ -108,7 +108,6 @@ class Dropdown extends Component {
     renderSelectField(other) {
         return (
             <SelectField
-                style={this.props.style}
                 value={this.state.value}
                 fullWidth={this.props.fullWidth}
                 {...other}
@@ -137,9 +136,8 @@ class Dropdown extends Component {
             },
         };
 
-
         return (
-            <div style={{ ...styles.fieldStyle, ...this.props.style }}>
+            <div style={styles.fieldStyle}>
                 <Dialog
                     title={this.props.labelText}
                     open={this.state.dialogOpen}
@@ -201,6 +199,10 @@ class Dropdown extends Component {
             style,
             ...other
         } = this.props;
+
+        if (style && style.display && style.display === 'none') {
+            return null;
+        }
 
         return (
             this.state.options.length > limit


### PR DESCRIPTION
Since not all components may be happy with setting the display to 'block' causing it to become unaligned when unhiding, a safer solution is to have it just return null if hidden.