### PR TITLE
Prevent removal of PTEAs defined in TETA

### DIFF
--- a/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/epics.js
+++ b/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/epics.js
@@ -44,13 +44,13 @@ const removeAttributeFromProgram = store => action$ => action$
 
         //Prevent removal of TEAs that are in selected TET
         if(has('trackedEntityType.trackedEntityTypeAttributes', program)) {
-            const attributesInTet = program.trackedEntityType.trackedEntityTypeAttributes
-                .map(teta => teta.trackedEntityAttribute.id);
-            const withoutTetAttrs = attributeIdsToRemove.filter(a => !attributesInTet.includes(a));
+            const attributesInTet = program.trackedEntityType.trackedEntityTypeAttributes;
+            const withoutTetAttrs = attributeIdsToRemove.filter(a => !attributesInTet
+                .find(teta => teta.trackedEntityAttribute.id === a));
 
             if(attributeIdsToRemove.length !== withoutTetAttrs.length) {
                 attributeIdsToRemove = withoutTetAttrs;
-                snackActions.show({message: "cannot_remove_program_attribute_defined_in_tet", translate: true})
+                snackActions.show({message: "cannot_remove_program_attribute_inherited_from_tet", translate: true})
             }
         }
 

--- a/src/forms/form-fields/drop-down-async.js
+++ b/src/forms/form-fields/drop-down-async.js
@@ -143,7 +143,6 @@ class DropDownAsync extends Component {
                     });
                 }
             })
-            .then(() => this.onChange({ target: { value: this.props.value ? this.props.value.id : this.props.value} }))
     }
 
     render() {

--- a/src/forms/form-fields/drop-down-async.js
+++ b/src/forms/form-fields/drop-down-async.js
@@ -142,7 +142,8 @@ class DropDownAsync extends Component {
                         )),
                     });
                 }
-            });
+            })
+            .then(() => this.onChange({ target: { value: this.props.value ? this.props.value.id : this.props.value} }))
     }
 
     render() {

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -2036,4 +2036,4 @@ confirm_delete_program_stage=Are you sure you want to delete this program stage?
 recipient_data_element=Data element recipient
 recipient_program_attribute=Program attribute recipient
 cannot_create_program_notification_without_program_stage=Cannot create Program notification without program stage
-cannot_remove_program_attribute_defined_in_tet=Cannot remove attribute defined in Tracked Entity Type
+cannot_remove_program_attribute_inherited_from_tet=Cannot remove attribute inherited from Tracked Entity Type

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -2036,3 +2036,4 @@ confirm_delete_program_stage=Are you sure you want to delete this program stage?
 recipient_data_element=Data element recipient
 recipient_program_attribute=Program attribute recipient
 cannot_create_program_notification_without_program_stage=Cannot create Program notification without program stage
+cannot_remove_program_attribute_defined_in_tet=Cannot remove attribute defined in Tracked Entity Type


### PR DESCRIPTION
Prevents the ability to remove programTrackedEntityAttributes in "Assign attributes"-tab that are defined in the selected trackedEntityType.

The TETAs are loaded after the initial loading of program metadata, as we cannot know if it's an event- or tracker-program beforehand.