### PR TITLE
Fix custom form. Add custom registration form

### DIFF
--- a/src/EditModel/EditModelForm.component.js
+++ b/src/EditModel/EditModelForm.component.js
@@ -89,7 +89,6 @@ const modelToEditAndModelForm$ = Observable.combineLatest(modelToEditStore, edit
         );
         const fieldConfigsWithAttributeFieldsAndUniqueValidators = fieldConfigsWithAttributeFields
             .map(fieldConfig => addUniqueValidatorWhenUnique(fieldConfig, modelToEdit));
-        console.log(fieldConfigs)
         return {
             fieldConfigs: fieldConfigsWithAttributeFieldsAndUniqueValidators,
             modelToEdit,
@@ -239,7 +238,6 @@ export default React.createClass({
 
     _onUpdateField(fieldName, value) {
         const fieldConfig = this.state.fieldConfigs.find(fieldConfig => fieldConfig.name == fieldName);
-        console.log(fieldConfig)
         if (fieldConfig && fieldConfig.beforeUpdateConverter) {
             return objectActions.update({ fieldName, value: fieldConfig.beforeUpdateConverter(value) });
         }

--- a/src/EditModel/EditModelForm.component.js
+++ b/src/EditModel/EditModelForm.component.js
@@ -89,7 +89,7 @@ const modelToEditAndModelForm$ = Observable.combineLatest(modelToEditStore, edit
         );
         const fieldConfigsWithAttributeFieldsAndUniqueValidators = fieldConfigsWithAttributeFields
             .map(fieldConfig => addUniqueValidatorWhenUnique(fieldConfig, modelToEdit));
-
+        console.log(fieldConfigs)
         return {
             fieldConfigs: fieldConfigsWithAttributeFieldsAndUniqueValidators,
             modelToEdit,
@@ -239,7 +239,7 @@ export default React.createClass({
 
     _onUpdateField(fieldName, value) {
         const fieldConfig = this.state.fieldConfigs.find(fieldConfig => fieldConfig.name == fieldName);
-
+        console.log(fieldConfig)
         if (fieldConfig && fieldConfig.beforeUpdateConverter) {
             return objectActions.update({ fieldName, value: fieldConfig.beforeUpdateConverter(value) });
         }

--- a/src/EditModel/event-program/create-data-entry-form/CreateDataEntryForm.component.js
+++ b/src/EditModel/event-program/create-data-entry-form/CreateDataEntryForm.component.js
@@ -93,7 +93,7 @@ class CreateDataEntryForm extends Component {
 
                     {this.renderTab(
                         this.getTranslation('custom'),
-                        <CustomForm />
+                        <CustomForm programStage={this.props.programStage} />
                     )}
                 </Tabs>
             </Paper>

--- a/src/EditModel/event-program/data-entry-form/CKEditor.js
+++ b/src/EditModel/event-program/data-entry-form/CKEditor.js
@@ -64,13 +64,13 @@ export default class CKEditor extends Component {
         return false;
     }
 
-    setContainerRef(textarea) {
+    setContainerRef = (textarea) => {
         this.editorContainer = textarea;
     }
 
     render() {
         return (
-            <textarea ref={this.setContainerRef.bind(this)} />
+            <textarea ref={this.setContainerRef} />
         );
     }
 }

--- a/src/EditModel/event-program/data-entry-form/EditCustomFormProgramStage.js
+++ b/src/EditModel/event-program/data-entry-form/EditCustomFormProgramStage.js
@@ -90,7 +90,7 @@ class EditDataEntryForm extends React.Component {
                 // The API returns "dataElementId.categoryOptionId", which are transformed to the format expected by
                 // custom forms: "dataElementId-categoryOptionId-val"
                 this.operands = dataElements
-                  //  .map(programStageDataElementWithProgramId(programStage.id))
+                    .map(programStageDataElementWithProgramId(programStage.id))
                     .filter(op => op.id.indexOf('.') !== -1)
                     .reduce((out, op) => {
                         const id = `${op.id.split('.').join('-')}-val`;

--- a/src/EditModel/event-program/data-entry-form/EditCustomRegistrationForm.js
+++ b/src/EditModel/event-program/data-entry-form/EditCustomRegistrationForm.js
@@ -116,16 +116,6 @@ class EditDataEntryForm extends React.Component {
     componentWillUnmount() {
         this.disposables.forEach(disposable => disposable.unsubscribe());
     }
-    //FIX loosing input-position on input
-    componentWillReceiveProps({ dataEntryForm }) {
-        if (this.state.dataEntryForm && dataEntryForm !== this.state.dataEntryForm) {
-            const { outHtml } = processFormData(getOr('', 'htmlCode', dataEntryForm), this.operands, elementPatterns.combinedIdPattern);
-
-            const formHtml = outHtml || '';
-
-            //this._editor.setData(formHtml);
-        }
-    }
 
     handleDeleteClick() {
         this.props.onFormDelete();
@@ -154,23 +144,27 @@ class EditDataEntryForm extends React.Component {
     handleEditorChanged = (editorData) => {
        // this.processFormData.call(this, editorData)
        // return;
-        const { usedIds, outHtml} = processFormData(editorData, this.operands, elementPatterns.combinedIdPattern);
+        const { usedIds, outHtml} = processFormData(editorData, this.props.elements, elementPatterns.attributeid);
+        console.log("ISEQUAL?", outHtml === editorData)
+        console.log(usedIds)
+        console.log(outHtml)
         this.setState({
             usedIds,
         }, () => {
             // Emit a value when the html changed
-            if (!this.state.dataEntryForm ||this.state.dataEntryForm.htmlCode !== outHtml) {
+            if (!this.state.dataEntryForm || this.state.dataEntryForm.htmlCode !== outHtml) {
                 console.log("FORM CHANGE")
                 this.props.onFormChange(outHtml);
             }
         });
     }
 
-    insertElement(id) {
+    insertElement(id, fieldType="attributeid" ) {
+        console.log(fieldType)
         if (this.state.usedIds.indexOf(id) !== -1) {
             return;
         }
-        return insElem(id, this.props.elements[id], this._editor);
+        return insElem(id, this.props.elements[id], this._editor, fieldType);
 
         this._editor.insertHtml(this.generateHtml(id), 'unfiltered_html');
         this.setState(state => ({ usedIds: state.usedIds.concat(id) }));

--- a/src/EditModel/event-program/data-entry-form/PaletteSection.js
+++ b/src/EditModel/event-program/data-entry-form/PaletteSection.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import pure from 'recompose/pure';
+
+function PaletteSection({ keySet, label, filter, expand, expandClick, usedIds, insertFn, styles }, { d2 }) {
+    const filteredItems = Object.keys(keySet)
+        .filter(key => !filter.length || filter.every(
+            filter => keySet[key].toLowerCase().indexOf(filter.toLowerCase()) !== -1
+        ));
+
+    const cellClass = label === expand ? 'cell expanded' : 'cell';
+
+    return (
+        <div className={cellClass}>
+            <div style={{...styles}} className="header" onClick={expandClick}>
+                <div className="arrow">&#9656;</div>
+                {d2.i18n.getTranslation(label)}:
+                <div className="count">{filteredItems.length}</div>
+            </div>
+            <div className="items">
+                {
+                    filteredItems
+                        .sort((a, b) => keySet[a] ? keySet[a].localeCompare(keySet[b]) : a.localeCompare(b))
+                        .map((key) => {
+                            // Active items are items that are not already added to the form
+                            const isActive = usedIds.indexOf(key) === -1;
+                            const className = isActive ? 'item active' : 'item inactive';
+                            const name = keySet[key].name || keySet[key];
+
+                            return (
+                                <div key={key} className={className} title={name}>
+                                    <a onClick={insertFn[key]}>{name}</a>
+                                </div>
+                            );
+                        })
+                }
+
+            </div>
+        </div>
+    );
+}
+
+PaletteSection.contextTypes = {
+    d2: React.PropTypes.object,
+};
+
+export const PurePaletteSection = pure(PaletteSection);
+export default PurePaletteSection;

--- a/src/EditModel/event-program/data-entry-form/__tests__/dataEntryFormUtils.spec.js
+++ b/src/EditModel/event-program/data-entry-form/__tests__/dataEntryFormUtils.spec.js
@@ -1,0 +1,46 @@
+import * as utils from '../dataEntryFormUtils';
+
+describe('dataEntryFormUtils', () => {
+    let editor = {
+        insertHtml: jest.fn(),
+        getSelection: jest.fn(() => ({getRanges: jest.fn(() => ([{
+            moveToElementEditablePosition: jest.fn(),
+            endContainer: {}
+        }]))}))
+    }
+    let elements;
+    const initialHTML =
+        '<p><input id="ZzYYXq4fJie-FqlgKAG8HOu-val" name="entryfield" title="MCH Measles dose" value="[ MCH Measles dose ]"/><input id="ZzYYXq4fJie-hDZbpskhqDd-val" name="entryfield" title="MCH HIV Test Type" value="[ MCH HIV Test Type ]"/><input id="ZzYYXq4fJie-BeynU4L6VCQ-val" name="entryfield" title="MCH Results given to caretaker" value="[ MCH Results given to caretaker ]"/></p>';
+    beforeEach(() => {
+        elements = {
+            'ZzYYXq4fJie-sj3j9Hwc7so-val': 'MCH Child ARVs',
+            'ZzYYXq4fJie-pOe0ogW4OWd-val': 'MCH DPT dose',
+            'ZzYYXq4fJie-hDZbpskhqDd-val': 'MCH HIV Test Type',
+            'ZzYYXq4fJie-X8zyunlgUfM-val': 'MCH Infant Feeding',
+            'ZzYYXq4fJie-cYGaxwK615G-val': 'MCH Infant HIV Test Result',
+            'ZzYYXq4fJie-GQY2lXrypjO-val': 'MCH Infant Weight  (g)',
+            'ZzYYXq4fJie-lNNb3truQoi-val': 'MCH IPT dose',
+            'ZzYYXq4fJie-FqlgKAG8HOu-val': 'MCH Measles dose',
+            'ZzYYXq4fJie-vTUhAUZFoys-val': 'MCH Penta dose',
+            'ZzYYXq4fJie-BeynU4L6VCQ-val': 'MCH Results given to caretaker',
+            'ZzYYXq4fJie-aei1xRjSU2l-val': 'MCH Septrin Given',
+            'ZzYYXq4fJie-OuJ6sgPyAbC-val': 'MCH Visit Comment',
+            'ZzYYXq4fJie-HLmTEmupdX0-val': 'MCH Vit A',
+            'ZzYYXq4fJie-rxBfISxXS2U-val': 'MCH Yellow fever dose',
+        };
+    });
+
+    describe('processForm()', () => {
+        test('it should work with empty formData', () => {
+            const dataEntryForm = initialHTML;
+            const { usedIds, outHtml } = utils.processFormData(
+                dataEntryForm,
+                elements,
+                utils.elementPatterns.combinedIdPattern
+            );
+            console.log(outHtml);
+            expect(outHtml).toBe(initialHTML)
+        });
+    });
+
+});

--- a/src/EditModel/event-program/data-entry-form/actions.js
+++ b/src/EditModel/event-program/data-entry-form/actions.js
@@ -8,6 +8,6 @@ export const dataEntryFormRemove = programStageId => ({ type: PROGRAM_STAGE_DATA
 export const PROGRAM_DATA_ENTRY_FORM_FIELD_CHANGED = 'PROGRAM_DATA_ENTRY_FORM_FIELD_CHANGED';
 export const PROGRAM_DATA_ENTRY_FORM_REMOVE = 'PROGRAM_DATA_ENTRY_FORM_REMOVE';
 
-export const programDataEntryFormChanged = (programId, field, value) => ({ type: PROGRAM_DATA_ENTRY_FORM_FIELD_CHANGED, payload: { program: programId, field, value } });
+export const programDataEntryFormChanged = (field, value) => ({ type: PROGRAM_DATA_ENTRY_FORM_FIELD_CHANGED, payload: { field, value } });
 
 export const programDataEntryFormRemove = programId => ({ type: PROGRAM_DATA_ENTRY_FORM_REMOVE, payload: programId });

--- a/src/EditModel/event-program/data-entry-form/actions.js
+++ b/src/EditModel/event-program/data-entry-form/actions.js
@@ -4,3 +4,10 @@ export const PROGRAM_STAGE_DATA_ENTRY_FORM_REMOVE = 'PROGRAM_STAGE_DATA_ENTRY_FO
 export const dataEntryFormChanged = (programStageId, field, value) => ({ type: PROGRAM_STAGE_DATA_ENTRY_FORM_FIELD_CHANGED, payload: { programStage: programStageId, field, value } });
 
 export const dataEntryFormRemove = programStageId => ({ type: PROGRAM_STAGE_DATA_ENTRY_FORM_REMOVE, payload: programStageId });
+
+export const PROGRAM_DATA_ENTRY_FORM_FIELD_CHANGED = 'PROGRAM_DATA_ENTRY_FORM_FIELD_CHANGED';
+export const PROGRAM_DATA_ENTRY_FORM_REMOVE = 'PROGRAM_DATA_ENTRY_FORM_REMOVE';
+
+export const programDataEntryFormChanged = (programId, field, value) => ({ type: PROGRAM_DATA_ENTRY_FORM_FIELD_CHANGED, payload: { program: programId, field, value } });
+
+export const programDataEntryFormRemove = programId => ({ type: PROGRAM_DATA_ENTRY_FORM_REMOVE, payload: programId });

--- a/src/EditModel/event-program/data-entry-form/dataEntryFormUtils.js
+++ b/src/EditModel/event-program/data-entry-form/dataEntryFormUtils.js
@@ -30,8 +30,6 @@ export function generateHtmlForField(id, styleAttr, disabledAttr, label, nameAtt
     const disabled = disabledAttr ? ` disabled=${disabledAttr}` : '';
 
     const attr = `name="${nameAttr}" title="${label}" value="[ ${label} ]"${style}${disabled}`.trim();
-    console.log(attr)
-    console.log("FIELDTYPE", fieldType)
     return `<input ${fieldType}="${id}" ${attr}/>`;
 
 }
@@ -94,13 +92,9 @@ export function processFormData(formData, elements, idPattern) {
         const inputStyle = (/style="(.*?)"/.exec(inputHtml) || ['', ''])[1];
         const inputDisabled = /disabled/.exec(inputHtml) !== null;
 
-        const idMatch = idPattern.exec(inputHtml);
         const allMatch = allPatterns.exec(inputHtml);
         const { idString, id, fieldType} = getFieldInfoFromMatch(allMatch)
-        console.log(idString)
-        console.log(id)
-        console.log(allMatch)
-        console.log(idMatch)
+
         if (idString && id) {
          //   console.log(idMatch);
             usedIds.push(id);
@@ -139,13 +133,10 @@ export function bindFuncsToKeys(obj, func, selfArg, extraArgs) {
 }
 
 export function insertElement(id, label, editor, fieldType = 'id') {
-    console.log(fieldType)
     const elementHtml = generateHtmlForField(id, null, null, label, undefined, fieldType);
-    console.log("ElementHTML", elementHtml);
     editor.insertHtml(elementHtml, 'unfiltered_html');
     // Move the current selection to just after the newly inserted element
     const range = editor.getSelection().getRanges()[0];
-    console.log(range)
     range && range.moveToElementEditablePosition(range.endContainer, true);
 }
 

--- a/src/EditModel/event-program/data-entry-form/dataEntryFormUtils.js
+++ b/src/EditModel/event-program/data-entry-form/dataEntryFormUtils.js
@@ -55,6 +55,15 @@ export function processFormData(formData, elements, idPattern) {
     }
 }
 
+/**
+ * Helper to bind the keys of an object to given function
+ * So that multiple elements can be bound to the same function.
+ * The first parameter of each bound function will be the key.
+ * @param obj Object with keys to bind
+ * @param func Function to bind each key to
+ * @param selfArg this context of the function
+ * @returns {{}} - And object where each property is a bound function
+ */
 export function bindFuncsToKeys(obj, func, selfArg) {
     const boundFuncs = {};
     Object.keys(obj).forEach((x) => {
@@ -67,5 +76,12 @@ export function insertElement(id, label, editor) {
     editor.insertHtml(generateHtmlForField(id, null, null, label), 'unfiltered_html');
     // Move the current selection to just after the newly inserted element
     const range = editor.getSelection().getRanges()[0];
-    range.moveToElementEditablePosition(range.endContainer, true);
+    console.log(range)
+    range && range.moveToElementEditablePosition(range.endContainer, true);
+}
+
+export function insertFlag(img, editor) {
+    editor.insertHtml(`<img src="../dhis-web-commons/flags/${img}" />`, 'unfiltered_html');
+    const range = editor.getSelection().getRanges()[0];
+    range && range.moveToElementEditablePosition(range.endContainer, true);
 }

--- a/src/EditModel/event-program/data-entry-form/dataEntryFormUtils.js
+++ b/src/EditModel/event-program/data-entry-form/dataEntryFormUtils.js
@@ -5,22 +5,52 @@ const inputPattern = /<input.*?\/>/gi;
 /* AttributeIdPattern is used in tracker-programs Custom registration forms
    programIdPattern is used in tracker-programs Custom registration forms
         Fixed to incidentDate and enrollmentDate
-* dataElementCateGoryOptionIdPattern is used for:
-*   - Event-programs data entry form (dataelementId-categoryOptionId)
-*   - Tracker-programs Data entry form (programStageId-dataelementId)*/
+* combinedIdPattern is used for:
+*   - Event-programs data entry form (dataElementId-categoryOptionId)
+*   - Tracker-programs Data entry form (programStageId-dataElementId)*/
 export const elementPatterns = {
     attributeIdPattern: /attributeid="(\w*?)"/,
     programIdPattern: /programid="(\w*?)"/,
-    dataElementCategoryOptionIdPattern: /id="(\w*?)-(\w*?)-val"/ //TODO: rename to combinedIdPattern?
+    combinedIdPattern: /id="(\w*?)-(\w*?)-val"/
 }
 
-export function generateHtmlForField(id, styleAttr, disabledAttr, label, nameAttr = "entryfield") {
+const fieldTypes = {
+    'programid': 'programIdPattern',
+    'attributeid': 'attributeIdPattern',
+    'id': 'combinedIdPattern'
+}
+
+const allPatterns = /attributeid="(\w*?)"|programid="(\w*?)"|id="(\w*?)-(\w*?)-val"/
+
+//These elements are static for Custom Registration Form
+const staticElements = [
+    'incidentDate',
+    'enrollmentDate'
+]
+
+export function generateHtmlForField(id, styleAttr, disabledAttr, label, nameAttr = "entryfield", fieldType='id') {
     const style = styleAttr ? ` style=${styleAttr}` : '';
     const disabled = disabledAttr ? ` disabled=${disabledAttr}` : '';
 
     const attr = `name="${nameAttr}" title="${label}" value="[ ${label} ]"${style}${disabled}`.trim();
-    return `<input id="${id}" ${attr}/>`;
+    return `<input ${fieldType}="${id}" ${attr}/>`;
 
+}
+
+/* Operands with ID's that contain a dot ('.') are a combined IDs of two objects.
+ The API returns ie. "dataElementId.categoryOptionId", which are transformed to the format expected by
+ custom forms: "dataElementId-categoryOptionId-val"
+    This is used for programStageId-dataElementId for Tracker-programs.
+    And dataElementId-categoryOptionId for event-programs
+ */
+export function transformElementsToCustomForm(elements) {
+    elements
+        .filter(op => op.id.indexOf('.') !== -1)
+        .reduce((out, op) => {
+            const id = `${op.id.split('.').join('-')}-val`;
+            out[id] = op.displayName; // eslint-disable-line
+            return out;
+        }, {});
 }
 
 export function processFormData(formData, elements, idPattern) {
@@ -40,9 +70,10 @@ export function processFormData(formData, elements, idPattern) {
         const inputDisabled = /disabled/.exec(inputHtml) !== null;
 
         const idMatch = idPattern.exec(inputHtml);
-
+        const allMatch = allPatterns.exec(inputHtml);
+        console.log(allMatch)
         if (idMatch) {
-            console.log(idMatch);
+         //   console.log(idMatch);
             const id = idMatch.length > 2 ? `${idMatch[1]}-${idMatch[2]}-val` : `${idMatch[1]}`;
             usedIds.push(id);
             const label = elements && elements[id];
@@ -54,7 +85,7 @@ export function processFormData(formData, elements, idPattern) {
         inputElement = inputPattern.exec(inHtml);
     }
     outHtml += inHtml.substr(inPos);
-    console.log(outHtml)
+    //console.log(outHtml)
     return {
         usedIds,
         outHtml
@@ -68,18 +99,20 @@ export function processFormData(formData, elements, idPattern) {
  * @param obj Object with keys to bind
  * @param func Function to bind each key to
  * @param selfArg this context of the function
+ * @param extraArgs Any extra arguments to bind to function
  * @returns {{}} - And object where each property is a bound function
  */
-export function bindFuncsToKeys(obj, func, selfArg) {
+export function bindFuncsToKeys(obj, func, selfArg, ...extraArgs) {
     const boundFuncs = {};
     Object.keys(obj).forEach((x) => {
-        boundFuncs[x] = func.bind(selfArg, x);
+        boundFuncs[x] = func.bind(selfArg, x, extraArgs);
     });
     return boundFuncs;
 }
 
-export function insertElement(id, label, editor) {
-    editor.insertHtml(generateHtmlForField(id, null, null, label), 'unfiltered_html');
+export function insertElement(id, label, editor, fieldType = 'id') {
+    console.log("ASF")
+    editor.insertHtml(generateHtmlForField(id, null, null, label, undefined, ), 'unfiltered_html');
     // Move the current selection to just after the newly inserted element
     const range = editor.getSelection().getRanges()[0];
     console.log(range)

--- a/src/EditModel/event-program/data-entry-form/dataEntryFormUtils.js
+++ b/src/EditModel/event-program/data-entry-form/dataEntryFormUtils.js
@@ -1,0 +1,71 @@
+import log from 'loglevel';
+
+const inputPattern = /<input.*?\/>/gi;
+
+export const elementPatterns = {
+    attributeIdPattern: /attributeid="(\w*?)"/,
+    programIdPattern: /programid="(\w*?)"/,
+    dataElementCategoryOptionIdPattern: /id="(\w*?)-(\w*?)-val"/
+}
+
+export function generateHtmlForField(id, styleAttr, disabledAttr, label, nameAttr = "entryfield") {
+    const style = styleAttr ? ` style=${styleAttr}` : '';
+    const disabled = disabledAttr ? ` disabled=${disabledAttr}` : '';
+
+    const attr = `name="${nameAttr}" title="${label}" value="[ ${label} ]"${style}${disabled}`.trim();
+    return `<input id="${id}" ${attr}/>`;
+
+}
+
+export function processFormData(formData, elements, idPattern) {
+    const inHtml = formData;
+    let outHtml = '';
+
+    const usedIds = [];
+
+    let inputElement = inputPattern.exec(inHtml);
+    let inPos = 0;
+    while (inputElement !== null) {
+        outHtml += inHtml.substr(inPos, inputElement.index - inPos);
+        inPos = inputPattern.lastIndex;
+
+        const inputHtml = inputElement[0];
+        const inputStyle = (/style="(.*?)"/.exec(inputHtml) || ['', ''])[1];
+        const inputDisabled = /disabled/.exec(inputHtml) !== null;
+
+        const idMatch = idPattern.exec(inputHtml);
+
+        if (idMatch) {
+            console.log(idMatch);
+            const id = idMatch.length > 2 ? `${idMatch[1]}-${idMatch[2]}-val` : `${idMatch[1]}`;
+            usedIds.push(id);
+            const label = elements && elements[id];
+            outHtml += generateHtmlForField(id, inputStyle, inputDisabled, label);
+        } else {
+            outHtml += inputHtml;
+        }
+
+        inputElement = inputPattern.exec(inHtml);
+    }
+    outHtml += inHtml.substr(inPos);
+    console.log(outHtml)
+    return {
+        usedIds,
+        outHtml
+    }
+}
+
+export function bindFuncsToKeys(obj, func, selfArg) {
+    const boundFuncs = {};
+    Object.keys(obj).forEach((x) => {
+        boundFuncs[x] = func.bind(selfArg, x);
+    });
+    return boundFuncs;
+}
+
+export function insertElement(id, label, editor) {
+    editor.insertHtml(generateHtmlForField(id, null, null, label), 'unfiltered_html');
+    // Move the current selection to just after the newly inserted element
+    const range = editor.getSelection().getRanges()[0];
+    range.moveToElementEditablePosition(range.endContainer, true);
+}

--- a/src/EditModel/event-program/data-entry-form/dataEntryFormUtils.js
+++ b/src/EditModel/event-program/data-entry-form/dataEntryFormUtils.js
@@ -2,10 +2,16 @@ import log from 'loglevel';
 
 const inputPattern = /<input.*?\/>/gi;
 
+/* AttributeIdPattern is used in tracker-programs Custom registration forms
+   programIdPattern is used in tracker-programs Custom registration forms
+        Fixed to incidentDate and enrollmentDate
+* dataElementCateGoryOptionIdPattern is used for:
+*   - Event-programs data entry form (dataelementId-categoryOptionId)
+*   - Tracker-programs Data entry form (programStageId-dataelementId)*/
 export const elementPatterns = {
     attributeIdPattern: /attributeid="(\w*?)"/,
     programIdPattern: /programid="(\w*?)"/,
-    dataElementCategoryOptionIdPattern: /id="(\w*?)-(\w*?)-val"/
+    dataElementCategoryOptionIdPattern: /id="(\w*?)-(\w*?)-val"/ //TODO: rename to combinedIdPattern?
 }
 
 export function generateHtmlForField(id, styleAttr, disabledAttr, label, nameAttr = "entryfield") {

--- a/src/EditModel/event-program/data-entry-form/epics.js
+++ b/src/EditModel/event-program/data-entry-form/epics.js
@@ -2,10 +2,11 @@ import { Observable } from 'rxjs';
 import { getOr, get, find, isEqual, compose } from 'lodash/fp';
 import log from 'loglevel';
 import { combineEpics } from 'redux-observable';
-import { PROGRAM_STAGE_DATA_ENTRY_FORM_FIELD_CHANGED, PROGRAM_STAGE_DATA_ENTRY_FORM_REMOVE } from './actions';
+import { PROGRAM_STAGE_DATA_ENTRY_FORM_FIELD_CHANGED, PROGRAM_STAGE_DATA_ENTRY_FORM_REMOVE, PROGRAM_DATA_ENTRY_FORM_FIELD_CHANGED, PROGRAM_DATA_ENTRY_FORM_REMOVE } from './actions';
 import eventProgramStore from '../eventProgramStore';
 import { generateUid } from 'd2/lib/uid';
 import { getInstance } from 'd2/lib/d2';
+import eventProgram from "../../../config/field-overrides/program";
 
 const d2$ = Observable.fromPromise(getInstance());
 
@@ -71,4 +72,49 @@ const dataEntryFormRemoveEpic = action$ => action$
     })
     .mergeMapTo(Observable.never());
 
-export default combineEpics(dataEntryFormChangedEpic, dataEntryFormRemoveEpic);
+
+//Used for custom registration form. On the program object
+
+const ProgramDataEntryFormChangedEpic = action$ => action$
+    .ofType(PROGRAM_DATA_ENTRY_FORM_FIELD_CHANGED)
+    .combineLatest(d2$, (action, d2) => ({ action, d2 }))
+    .mergeMap(({ action, d2 }) => {
+        const fieldName = get('payload.field', action);
+        const value = get('payload.value', action);
+        const storeState = eventProgramStore.getState();
+        const program = storeState.program;
+        let dataEntryForm = storeState.program.dataEntryForm;
+
+        // Set the uid in case we're dealing with a new form
+        if(!dataEntryForm || !dataEntryForm.id) {
+            const id = generateUid();
+            dataEntryForm = d2.models.dataEntryForm.create({id, name: program.displayName})
+        }
+
+        log.debug('Setting', fieldName, 'to', value);
+        dataEntryForm[fieldName] = value;
+
+
+        if (!program.dataEntryForm) {
+            program.dataEntryForm = dataEntryForm;
+        }
+
+        // Force a state update on the store
+        eventProgramStore.setState({});
+        return Observable.empty();
+    })
+    .flatMapTo(Observable.never());
+
+const ProgramDataEntryFormRemoveEpic = action$ => action$
+    .ofType(PROGRAM_DATA_ENTRY_FORM_REMOVE)
+    .combineLatest(d2$, (action, d2) => ({ action, d2 }))
+    .mergeMap(({ action, d2 }) => {
+        const storeState = eventProgramStore.getState();
+        const programStageId = action.payload;
+
+        program.dataEntryForm = undefined;
+        eventProgramStore.setState({});
+    })
+    .mergeMapTo(Observable.never());
+
+export default combineEpics(dataEntryFormChangedEpic, dataEntryFormRemoveEpic, ProgramDataEntryFormChangedEpic, ProgramDataEntryFormRemoveEpic);

--- a/src/EditModel/event-program/data-entry-form/epics.js
+++ b/src/EditModel/event-program/data-entry-form/epics.js
@@ -92,12 +92,10 @@ const ProgramDataEntryFormChangedEpic = action$ => action$
             const id = generateUid();
             dataEntryForm = d2.models.dataEntryForm.create({id, name: program.displayName})
         }
-
         log.debug('Setting', fieldName, 'to', value);
         dataEntryForm[fieldName] = value;
 
-
-        if (!program.dataEntryForm) {
+        if (!program.dataEntryForm || !program.dataEntryForm.id) {
             program.dataEntryForm = dataEntryForm;
         }
 

--- a/src/EditModel/event-program/data-entry-form/epics.js
+++ b/src/EditModel/event-program/data-entry-form/epics.js
@@ -79,9 +79,11 @@ const ProgramDataEntryFormChangedEpic = action$ => action$
     .ofType(PROGRAM_DATA_ENTRY_FORM_FIELD_CHANGED)
     .combineLatest(d2$, (action, d2) => ({ action, d2 }))
     .mergeMap(({ action, d2 }) => {
+
         const fieldName = get('payload.field', action);
         const value = get('payload.value', action);
         const storeState = eventProgramStore.getState();
+
         const program = storeState.program;
         let dataEntryForm = storeState.program.dataEntryForm;
 
@@ -112,8 +114,9 @@ const ProgramDataEntryFormRemoveEpic = action$ => action$
         const storeState = eventProgramStore.getState();
         const programStageId = action.payload;
 
-        program.dataEntryForm = undefined;
+        storeState.program.dataEntryForm = undefined;
         eventProgramStore.setState({});
+        return Observable.empty();
     })
     .mergeMapTo(Observable.never());
 

--- a/src/EditModel/event-program/epics.js
+++ b/src/EditModel/event-program/epics.js
@@ -242,7 +242,7 @@ function createEventProgramStoreStateFromMetadataResponse(
             );
 
         const program = createProgramModel(programs);
-        program.dataEntryForm = createDataEntryFormModel(getOr({}, 'dataEntryForm', program))
+        program.dataEntryForm = program.dataEntryForm ? createDataEntryFormModel(getOr({}, 'dataEntryForm', program)) : undefined
 
         return {
             program,

--- a/src/EditModel/event-program/epics.js
+++ b/src/EditModel/event-program/epics.js
@@ -241,11 +241,12 @@ function createEventProgramStoreStateFromMetadataResponse(
                 {},
             );
 
+        const program = createProgramModel(programs);
+        program.dataEntryForm = createDataEntryFormModel(getOr({}, 'dataEntryForm', program))
+
         return {
-            program: createProgramModel(programs),
-            programStages: createProgramStageModels(
-                getOr([], 'programStages', first(programs)),
-            ),
+            program,
+            programStages: createProgramStageModels(programStages),
             programStageNotifications: extractProgramNotifications(
                 programStages,
             ),
@@ -334,7 +335,7 @@ export const programModelSave = action$ =>
             return successObs.concat(Observable.of(notifyUser({message: 'no_changes_to_be_saved', translate: true})).do(() =>
                 goToAndScrollUp('/list/programSection/program'),
             ));
-        });
+        }).catch(e => console.log(e));
 
 export const programModelSaveResponses = action$ =>
     Observable.merge(

--- a/src/EditModel/event-program/eventProgramStore.js
+++ b/src/EditModel/event-program/eventProgramStore.js
@@ -5,6 +5,8 @@ import { getOwnedPropertyJSON } from 'd2/lib/model/helpers/json';
 // ___ programSelector :: StoreState -> Model<Program>
 const programSelector = get('program');
 
+const progamDataEntrySelector = get('program.dataEntryForm');
+
 // ___ programStagesSelector :: StoreState -> Array<Model<ProgramStage>>
 const programStagesSelector = get('programStages');
 
@@ -71,6 +73,12 @@ export const getMetaDataToSend = (state) => {
     if (isProgramDirty(state)) {
         payload.programs = [programSelector(state)]
             .map(modelToJson);
+
+        //For custom-form
+        const programDataEntryForm = state.program.dataEntryForm;
+        if(programDataEntryForm && programDataEntryForm.isDirty()) {
+            payload.dataEntryForms  = [programDataEntryForm].map(modelToJson);
+        }
     }
 
     if (isProgramStageDirty(state)) {
@@ -107,15 +115,21 @@ export const getMetaDataToSend = (state) => {
         )
     }
 
+    //Program stage dataEntryForms
     if (hasDirtyDataEntryForms(state)) {
         const dataEntryForms = dataEntryFormsSelector(state);
-
-        payload.dataEntryForms = Object
+        const programStageDataEntryForms = Object
             .keys(dataEntryForms)
             .map(get(__, dataEntryForms))
             .filter(checkIfDirty)
             .map(modelToJson);
+
+        payload.dataEntryForms = payload.dataEntryForms ?
+            payload.dataEntryForms.concat(programStageDataEntryForms) : programStageDataEntryForms;
     }
+
+    console.log(payload)
+
 
 
     return payload;

--- a/src/EditModel/event-program/eventProgramStore.js
+++ b/src/EditModel/event-program/eventProgramStore.js
@@ -128,10 +128,6 @@ export const getMetaDataToSend = (state) => {
             payload.dataEntryForms.concat(programStageDataEntryForms) : programStageDataEntryForms;
     }
 
-    console.log(payload)
-
-
-
     return payload;
 };
 

--- a/src/EditModel/event-program/eventProgramStore.js
+++ b/src/EditModel/event-program/eventProgramStore.js
@@ -76,7 +76,7 @@ export const getMetaDataToSend = (state) => {
 
         //For custom-form
         const programDataEntryForm = state.program.dataEntryForm;
-        if(programDataEntryForm && programDataEntryForm.isDirty()) {
+        if(programDataEntryForm && programDataEntryForm.id && programDataEntryForm.isDirty()) {
             payload.dataEntryForms  = [programDataEntryForm].map(modelToJson);
         }
     }

--- a/src/EditModel/event-program/tracker-program/CustomRegistrationForm.js
+++ b/src/EditModel/event-program/tracker-program/CustomRegistrationForm.js
@@ -1,0 +1,26 @@
+import React, { Component } from 'react';
+import { get, compose } from 'lodash/fp';
+import Checkbox from 'material-ui/Checkbox';
+import programStore from '../eventProgramStore';
+import addD2Context from 'd2-ui/lib/component-helpers/addD2Context';
+
+class CustomRegistrationForm extends Component {
+    state = {
+        useCustom: !!this.props.model.dataEntryForm
+    }
+
+    handleUseCustom = (value) => {
+
+       // programStore.program.dataEntryForm =
+
+    }
+    render() {
+        console.log(this.state.useCustom)
+        return (
+            <div>
+                <Checkbox/>
+            </div>
+        )
+    }
+}
+export default addD2Context(CustomRegistrationForm);

--- a/src/EditModel/event-program/tracker-program/CustomRegistrationForm.js
+++ b/src/EditModel/event-program/tracker-program/CustomRegistrationForm.js
@@ -5,6 +5,15 @@ import programStore from '../eventProgramStore';
 import addD2Context from 'd2-ui/lib/component-helpers/addD2Context';
 import { CustomRegistrationDataEntryForm } from "../data-entry-form/EditCustomRegistrationForm";
 
+const styles = {
+    outer: {
+        marginTop: '24px',
+    },
+    checkbox: {
+        marginBottom: '24px'
+    }
+}
+
 class CustomRegistrationForm extends Component {
     state = {
         useCustom: !!this.props.model.dataEntryForm,
@@ -21,13 +30,14 @@ class CustomRegistrationForm extends Component {
     render() {
         console.log(this.state.useCustom);
         return (
-            <div>
+            <div style={styles.outer}>
                 <Checkbox
                     checked={this.state.useCustom}
                     onCheck={this.handleUseCustom}
                     label={this.context.d2.i18n.getTranslation(
                         'use_custom_registration_form'
                     )}
+                    style={styles.checkbox}
                 />
                 {this.state.useCustom && this.renderCustomForm()}
             </div>

--- a/src/EditModel/event-program/tracker-program/CustomRegistrationForm.js
+++ b/src/EditModel/event-program/tracker-program/CustomRegistrationForm.js
@@ -3,7 +3,7 @@ import { get, compose } from 'lodash/fp';
 import Checkbox from 'material-ui/Checkbox';
 import programStore from '../eventProgramStore';
 import addD2Context from 'd2-ui/lib/component-helpers/addD2Context';
-import { CustomRegistrationDataEntryForm } from "../data-entry-form/EditCustomFormProgramStage";
+import { CustomRegistrationDataEntryForm } from "../data-entry-form/EditCustomRegistrationForm";
 
 class CustomRegistrationForm extends Component {
     state = {

--- a/src/EditModel/event-program/tracker-program/CustomRegistrationForm.js
+++ b/src/EditModel/event-program/tracker-program/CustomRegistrationForm.js
@@ -3,24 +3,35 @@ import { get, compose } from 'lodash/fp';
 import Checkbox from 'material-ui/Checkbox';
 import programStore from '../eventProgramStore';
 import addD2Context from 'd2-ui/lib/component-helpers/addD2Context';
+import { CustomRegistrationDataEntryForm } from "../data-entry-form/EditCustomFormProgramStage";
 
 class CustomRegistrationForm extends Component {
     state = {
-        useCustom: !!this.props.model.dataEntryForm
-    }
+        useCustom: !!this.props.model.dataEntryForm,
+    };
 
-    handleUseCustom = (value) => {
+    handleUseCustom = (e, checked) => {
+        this.setState({ ...this.state, useCustom: checked });
+    };
 
-       // programStore.program.dataEntryForm =
+    renderCustomForm = () => {
+        return <CustomRegistrationDataEntryForm />
+    };
 
-    }
     render() {
-        console.log(this.state.useCustom)
+        console.log(this.state.useCustom);
         return (
             <div>
-                <Checkbox/>
+                <Checkbox
+                    checked={this.state.useCustom}
+                    onCheck={this.handleUseCustom}
+                    label={this.context.d2.i18n.getTranslation(
+                        'use_custom_registration_form'
+                    )}
+                />
+                {this.state.useCustom && this.renderCustomForm()}
             </div>
-        )
+        );
     }
 }
 export default addD2Context(CustomRegistrationForm);

--- a/src/EditModel/event-program/tracker-program/CustomRegistrationForm.js
+++ b/src/EditModel/event-program/tracker-program/CustomRegistrationForm.js
@@ -4,6 +4,7 @@ import Checkbox from 'material-ui/Checkbox';
 import programStore from '../eventProgramStore';
 import addD2Context from 'd2-ui/lib/component-helpers/addD2Context';
 import { CustomRegistrationDataEntryForm } from "../data-entry-form/EditCustomRegistrationForm";
+import { bindActionCreators } from 'redux';
 
 const styles = {
     outer: {
@@ -16,7 +17,7 @@ const styles = {
 
 class CustomRegistrationForm extends Component {
     state = {
-        useCustom: !!this.props.model.dataEntryForm,
+        useCustom: !!this.props.model.dataEntryForm && !!this.props.model.dataEntryForm.id,
     };
 
     handleUseCustom = (e, checked) => {
@@ -27,8 +28,15 @@ class CustomRegistrationForm extends Component {
         return <CustomRegistrationDataEntryForm />
     };
 
+
+    handleNameChange = (e, val) => {
+        console.log(e)
+        console.log(val);
+
+
+    }
+
     render() {
-        console.log(this.state.useCustom);
         return (
             <div style={styles.outer}>
                 <Checkbox
@@ -44,4 +52,5 @@ class CustomRegistrationForm extends Component {
         );
     }
 }
+
 export default addD2Context(CustomRegistrationForm);

--- a/src/EditModel/event-program/tracker-program/CustomRegistrationForm.js
+++ b/src/EditModel/event-program/tracker-program/CustomRegistrationForm.js
@@ -1,10 +1,8 @@
 import React, { Component } from 'react';
 import { get, compose } from 'lodash/fp';
 import Checkbox from 'material-ui/Checkbox';
-import programStore from '../eventProgramStore';
 import addD2Context from 'd2-ui/lib/component-helpers/addD2Context';
 import { CustomRegistrationDataEntryForm } from "../data-entry-form/EditCustomRegistrationForm";
-import { bindActionCreators } from 'redux';
 
 const styles = {
     outer: {
@@ -27,14 +25,6 @@ class CustomRegistrationForm extends Component {
     renderCustomForm = () => {
         return <CustomRegistrationDataEntryForm />
     };
-
-
-    handleNameChange = (e, val) => {
-        console.log(e)
-        console.log(val);
-
-
-    }
 
     render() {
         return (

--- a/src/EditModel/event-program/tracker-program/EnrollmentStep.js
+++ b/src/EditModel/event-program/tracker-program/EnrollmentStep.js
@@ -1,0 +1,34 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import mapPropsStream from 'recompose/mapPropsStream';
+import { get, compose } from 'lodash/fp';
+import {createFormFor} from "../../formHelpers";
+import {flattenRouterProps, wrapInPaper} from "../../componentHelpers";
+import programStore from "../eventProgramStore";
+import fieldOrder from "../../../config/field-config/field-order";
+import {editFieldChanged} from "../actions";
+import CustomRegistrationForm from './CustomRegistrationForm';
+const program$ = programStore.map(get('program'));
+const enrollmentFields = fieldOrder.for('enrollment');
+
+const mapDispatchToProps = dispatch =>
+    bindActionCreators({ editFieldChanged }, dispatch);
+
+const connectEditForm = compose(
+    flattenRouterProps,
+    connect(null, mapDispatchToProps),
+);
+
+const EnrollmentDetailsForm = connectEditForm(
+    createFormFor(program$, 'program', enrollmentFields, true, 'enrollment')
+);
+
+const EnrollmentDetails = props => (
+    <div>
+        <EnrollmentDetailsForm {...props}/>
+        <CustomRegistrationForm {...props} />
+    </div>
+)
+
+export default wrapInPaper(EnrollmentDetails);

--- a/src/EditModel/event-program/tracker-program/TrackerProgramStepperContent.js
+++ b/src/EditModel/event-program/tracker-program/TrackerProgramStepperContent.js
@@ -16,7 +16,7 @@ import { flattenRouterProps, wrapInPaper } from '../../componentHelpers';
 import fieldOrder from '../../../config/field-config/field-order';
 import AssignAttributes from './assign-tracked-entity-attributes/AssignAttributes';
 import ProgramStage from './program-stages/ProgramStage';
-
+import EnrollmentDetails from './EnrollmentStep';
 const stepperConfig = () => {
     const program$ = programStore.map(get('program'));
 
@@ -36,9 +36,9 @@ const stepperConfig = () => {
                 createFormFor(program$, 'program', trackerDetailsFields, true, 'trackerProgram'),
             ),
         ),
-        Enrollment: connectEditForm(
+        Enrollment: EnrollmentDetails,/*connectEditForm(
             wrapInPaper(createFormFor(program$, 'program', enrollmentFields, true, 'enrollment')),
-        ),
+        ), */
         AssignAttributes,
         ProgramStage,
         EditDataEntryForm,

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -2048,3 +2048,4 @@ add_enrollment_details=Add enrollment details
 manage_program_stages=Manage program stages
 success=Success
 notifications=Notifications
+use_custom_registration_form=Use custom registration form


### PR DESCRIPTION
Fixed a bunch of issues with custom forms by doing some refactoring.

There is still some refactoring that should be done, as EditCustomFormProgramStage and EditCustomRegistrationForm contains a lot of the same code, however we need the fix for 2.29.

DataEntryForm are used in dataSet, programsStages and program (custom registration form). 
It used the CKeditor, and I tried to extract common logic into a util-file. 
I did not touch the dataSet custom form, but it has a lot of the same code... However it would take me many hours to include that as well (but less now, as the util file should be somewhat generic).



Should fix these issues: 
https://jira.dhis2.org/browse/DHIS2-3167
https://jira.dhis2.org/browse/DHIS2-3199
https://jira.dhis2.org/browse/DHIS2-3225