### PR TITLE
DHIS2-3190 Fixed long snackBar messages that hides action button

### DIFF
--- a/src/Snackbar/SnackbarContainer.component.js
+++ b/src/Snackbar/SnackbarContainer.component.js
@@ -15,7 +15,7 @@ const snackBarTranslate = get('snackBar.translate');
 let SnackBar = (props, { d2 }) => (
     <Snackbar
         style={{ maxWidth: 'auto', zIndex: 5 }}
-        bodyStyle={{ maxWidth: 'auto' }}
+        bodyStyle={{ maxWidth: 'auto', height: 'auto' }}
         message={props.translate ? d2.i18n.getTranslation(props.message) : props.message}
         action={props.action}
         autoHideDuration={props.autoHideDuration}


### PR DESCRIPTION
Set bodyStyle height to auto so that long messages wouldnt hide actionButton

This will push the action button below the message if its close to screen width. Not really the best of solutions, but SnackBar doesn't have multiline support. 

The question is however if its worth the work of implementing a custom multiline support error messages shouldn't really be that long in the first place. The user doesn't need to know that 'class org.hisp.dhis.dataelement.DataElement' don't support Data Sharing only that the selected object does not support Data Sharing . 