### PR TITLE
DHIS2-3336 Generate new uid client-side when saving/cloning objects

### DIFF
--- a/src/EditModel/objectActions.js
+++ b/src/EditModel/objectActions.js
@@ -132,8 +132,11 @@ objectActions.saveObject
             }
         };
 
+        // DHIS2-3336: Related to DHIS2-2342. We need to generate
+        // a new uid when saving/cloning objects before sending it to
+        // the server to ensure that cloned objects get a new uid.
         return modelToEditStore
-            .save(action.data.id)
+            .save(generateUid())
             .subscribe(successHandler, errorHandler);
     }, (e) => {
         log.error(e);
@@ -265,7 +268,7 @@ objectActions.saveObject
 
         const programRuleId = modelToEditStore.getState().id || (await api.get('/system/id')).codes[0];
 
-        // TODO (DHIS2-2342) The client should not need to generate a
+        // DHIS2-2342: The client should not need to generate a
         // new for the programRuleAction here to avoid highjacking the
         // reference to original. Cloning these complex objects should
         // be done on the backend to solve the entire category of bugs


### PR DESCRIPTION
This PR modifies the standard handler for saving and cloning objects to always generate a new UID client-side and send that to the server.

Some notes:

- This does not apply to editing.
- This does apply to all object types which goes into the standard handler which have the same problems.
- This does not apply to objects which has special save handlers since they work slightly different and aren't in scope of DHIS2-3336.
- The async validator for "code" doesn't re-validate without changing the field (component problem I think).

I've tested the patch in the app for a while now and it seems to work.