### PR TITLE
Program assignment in orgunit-edit

### DIFF
--- a/src/EditModel/objectActions.js
+++ b/src/EditModel/objectActions.js
@@ -155,12 +155,12 @@ objectActions.saveObject
         const d2 = await getInstance();
         const organisationUnit = modelToEditStore.getState();
 
-        if (!organisationUnit.isDirty() && !organisationUnit.dataSets.isDirty()) {
+        if (!organisationUnit.isDirty() && !organisationUnit.dataSets.isDirty() && !organisationUnit.programs.isDirty()) {
             completeAction('no_changes_to_be_saved');
         } else {
             // The orgunit has to be saved before it can be linked to datasets so these operations are done sequentially
             organisationUnit.save()
-                .then(() => organisationUnit.dataSets.save(), (error) => {
+                .then(() => Promise.all([organisationUnit.dataSets.save(), organisationUnit.programs.save()]), (error) => {
                     log.error(error);
                     snackActions.show({
                         message: Array.isArray(error.messages)

--- a/src/config/field-config/field-order.js
+++ b/src/config/field-config/field-order.js
@@ -152,6 +152,8 @@ const fieldOrderByName = new Map([
         'phoneNumber',
         'coordinates',
         'dataSets',
+        'programs'
+
     ]],
     ['organisationUnitGroup', [
         'name',

--- a/src/config/field-rules.js
+++ b/src/config/field-rules.js
@@ -347,6 +347,17 @@ export default new Map([
             }],
         },
         {
+            field: 'programs',
+            when: [{
+                operator: 'SYSTEM_SETTING_IS_FALSE',
+                value: 'keyAllowObjectAssignment',
+            }],
+            operations: [{
+                field: 'programs',
+                type: 'HIDE_FIELD',
+            }],
+        },
+        {
             field: 'featureType',
             when: [{
                 field: 'coordinates',


### PR DESCRIPTION
Adds the ability for assigning programs in the origanisation unit edit-view.

This is so that it's faster to assign multiple programs to an orgunit, instead of manually going through the programs and adding orgunits.

See https://jira.dhis2.org/browse/DHIS2-2356.

Need to go to System Settings -> Access -> Check "Allow assigning object to related objects during add or update" for the programs to show up in organisation units.
 