### PR TITLE
Fixes bug that would cause OrgUnittree in sidebar to always select fallback

### DIFF
--- a/src/App/appStateStore.js
+++ b/src/App/appStateStore.js
@@ -99,7 +99,7 @@ async function getCurrentUserOrganisationUnits(disableCache = false) {
 }
 
 async function loadSelectedOrganisationUnitState() {
-    if (appState.state && appState.state.selectedOrganisationUnit && appState.state.selectedOrganisationUnit.length) {
+    if (appState.state && appState.state.selectedOrganisationUnit) {
         return appState.state.selectedOrganisationUnit;
     }
 

--- a/src/SideBar/SideBarContainer.component.js
+++ b/src/SideBar/SideBarContainer.component.js
@@ -33,6 +33,18 @@ class SideBarContainer extends React.Component {
         }
     }
 
+    getExpandedItems(orgUnitSearchHits) {
+        if (orgUnitSearchHits && orgUnitSearchHits.length) {
+            return [];
+        }
+
+        if (this.state.selectedOrganisationUnit) {
+            return [this.state.selectedOrganisationUnit.path];
+        }
+
+        return this.state.userOrganisationUnits.toArray().map(v => v.path).concat(this.state.initiallyExpanded || []);
+    }
+
     renderSidebarItems() {
         if (this.state.currentSubSection === 'organisationUnit' && !/#\/edit\//.test(document.location.hash)) {
             if (this.state.userOrganisationUnits && this.state.selectedOrganisationUnit) {
@@ -57,9 +69,7 @@ class SideBarContainer extends React.Component {
                         return ou;
                     });
 
-                const initiallyExpanded = orgUnitSearchHits && orgUnitSearchHits.length
-                    ? []
-                    : this.state.userOrganisationUnits.toArray().map(v => v.path).concat(this.state.initiallyExpanded || []);
+                const initiallyExpanded = this.getExpandedItems(orgUnitSearchHits);
 
                 return (
                     <div style={styles.wrapperStyle}>


### PR DESCRIPTION
- appState.state.selectedOrganisationUnit is a model, not an array
- because the condition included a check for .length the method loadSelectedOrganisationUnitState would never return the selectedOrganisationUnit but the users root instead