### PR TITLE
DHIS2-3547 2.28 backport for validation on save

### DIFF
--- a/src/EditModel/EditModelForm.component.js
+++ b/src/EditModel/EditModelForm.component.js
@@ -22,6 +22,9 @@ import { applyRulesToFieldConfigs, getRulesForModelType } from './form-rules';
 
 import { Step, Stepper, StepButton } from 'material-ui/Stepper';
 
+import getFirstInvalidFieldMessage from './form-helpers/validateFields';
+
+
 const currentSection$ = appState
     .filter(state => state.sideBar && state.sideBar.currentSection)
     .map(state => state.sideBar.currentSubSection)
@@ -115,7 +118,7 @@ export default React.createClass({
             isLoading: true,
             formState: {
                 validating: false,
-                valid: false,
+                valid: true,
                 pristine: true,
             },
             activeStep: 0,
@@ -197,6 +200,7 @@ export default React.createClass({
                     fields={this.state.fieldConfigs}
                     onUpdateField={this._onUpdateField}
                     onUpdateFormStatus={this._onUpdateFormStatus}
+                    ref={this.setFormRef}
                 />
                 <FormButtons>
                     <SaveButton
@@ -216,6 +220,10 @@ export default React.createClass({
         }
 
         return this.renderForm();
+    },
+
+    setFormRef(form) {
+        this.formRef = form;
     },
 
     setActiveStep(step) {
@@ -262,6 +270,16 @@ export default React.createClass({
 
     _saveAction(event) {
         event.preventDefault();
+
+        const invalidFieldMessage = getFirstInvalidFieldMessage(this.state.fieldConfigs, this.formRef);
+        if (invalidFieldMessage) {
+            snackActions.show({
+                message: `${this.getTranslation('missing_required_property_field')} ${invalidFieldMessage}`,
+                action: 'ok',
+            });
+            return;
+        }
+
         // Set state to saving so forms actions are being prevented
         this.setState({ isSaving: true });
 

--- a/src/EditModel/form-helpers/validateFields.js
+++ b/src/EditModel/form-helpers/validateFields.js
@@ -1,0 +1,66 @@
+import { get, find } from 'lodash/fp';
+
+/* *
+ * The result coming from FormBuilder validateField will contain an error message on fail and 
+ * a boolean true if it succeeds. This 
+ */
+const isInvalidField = validatedResult => validatedResult !== true;
+
+const isRequiredField = field => get('isRequired', field.fieldOptions) === true;
+
+const validateField = (field, formRef, formRefStateClone) => {
+    const validateResult = formRef.validateField(formRefStateClone, field.name, field.value);
+    return {
+        invalid: isInvalidField(validateResult),
+        step: field.step,
+        name: field.translatedName,
+    };
+};
+
+/* *
+ * Constructs the error message to present to the snackBar.
+ * Adds the step the field can be found on if present.
+ */
+const getErrorMessage = (field) => {
+    const fieldStep = field.step ? `On step ${field.step}` : '';
+
+    const errorMessage = `: ${field.name}. ${fieldStep}`;
+    return errorMessage;
+};
+
+/** 
+ * Will filter out all the fields that are required. 
+ * The it will validate the fields using the formBuilder
+ * and lastly fetch the first field that is required and invalid.
+ */
+const getFirstInvalidField = (fieldConfigs, formRef, formRefStateClone) =>
+    fieldConfigs
+        .filter(fieldConfig => isRequiredField(fieldConfig))
+        .map(fieldConfig => validateField(fieldConfig, formRef, formRefStateClone))
+        .find(field => field.invalid);
+
+/**
+ * Validate checks all the fields that are marked as required in the form.
+ * The validation will set the fields as invalid in the formbuilder and set
+ * the new state of the form.
+ * 
+ * If any the required fields are not valid not it will create a message string 
+ * of the first invalid field.
+ * 
+ * @returns {string} 
+ * The name and step/group of the invalid field.
+ * If no invalid field, it will return an empty string.
+ */
+export default function getFirstInvalidFieldMessage(fieldConfigs, formRef) {
+    const formRefStateClone = formRef.getStateClone();
+
+    const firstInvalidField = getFirstInvalidField(fieldConfigs, formRef, formRefStateClone);
+
+    if (!firstInvalidField) {
+        return '';
+    }
+    formRef.setState(formRefStateClone);
+
+    const errorMessage = getErrorMessage(firstInvalidField);
+    return errorMessage;
+}

--- a/src/EditModel/formHelpers.js
+++ b/src/EditModel/formHelpers.js
@@ -3,6 +3,8 @@ import FormFieldsForModel from '../forms/FormFieldsForModel';
 import FormFieldsManager from '../forms/FormFieldsManager';
 import fieldOrderNames from '../config/field-config/field-order';
 import fieldOverrides from '../config/field-overrides/index';
+import fieldGroups from '../config/field-config/field-groups';
+
 import { createFieldConfig, typeToFieldMap } from '../forms/fields';
 import mapPropsStream from 'recompose/mapPropsStream';
 import { identity, noop, compose } from 'lodash/fp';
@@ -18,6 +20,42 @@ function getLabelText(labelText, fieldConfig = {}) {
     return labelText;
 }
 
+// Translate the sync validator messages if there are any validators
+function translateValidators(fieldConfig, d2) {
+    if (fieldConfig.validators) {
+        fieldConfig.validators = fieldConfig.validators
+            .map(validator => ({
+                ...validator,
+                message: d2.i18n.getTranslation(validator.message),
+            }));
+    }
+}
+
+// Get the field's label with required indicator if the field is required
+// Save one translated label for validation messages
+function setRequiredFieldsLabelText(fieldConfig, d2) {
+    fieldConfig.translatedName = d2.i18n.getTranslation(fieldConfig.props.labelText);
+    fieldConfig.props.labelText = getLabelText(
+        fieldConfig.translatedName,
+        fieldConfig,
+    );
+}
+
+/* 
+ * If the modelType are grouped in field-groups.js, the step number and group/step name 
+ * will be added to the fieldConfig. This string can later be used for the validating
+ * step in EditModelForm.isRequiredFieldsValid to tell the user which step to find the 
+ * non-valid required field.
+ */
+function setRequiredFieldsStepName(fieldConfig, modelType, d2) {
+    // TODO: Find way to fix programNotificationTemplate sending the correct modelType
+    if (fieldGroups.isGroupedFields(modelType) && modelType !== 'programNotificationTemplate') {
+        const stepNo = fieldGroups.groupNoByName(fieldConfig.name, modelType);
+        const stepName = fieldGroups.groupNameByStep(stepNo, modelType);
+        fieldConfig.step = `${stepNo + 1}: ${d2.i18n.getTranslation(stepName)}`;
+    }
+}
+
 export async function createFieldConfigForModelTypes(modelType, forcedFieldOrderNames, includeAttributes = true) {
     const d2 = await getInstance();
 
@@ -30,18 +68,9 @@ export async function createFieldConfigForModelTypes(modelType, forcedFieldOrder
 
     return formFieldsManager.getFormFieldsForModel({ modelDefinition: d2.models[modelType] })
         .map((fieldConfig) => {
-            // Translate the sync validator messages if there are any validators
-            if (fieldConfig.validators) {
-                fieldConfig.validators = fieldConfig.validators
-                    .map(validator => ({
-                        ...validator,
-                        message: d2.i18n.getTranslation(validator.message),
-                    }));
-            }
-
-            // Get the field's label with required indicator if the field is required
-            fieldConfig.props.labelText = getLabelText(d2.i18n.getTranslation(fieldConfig.props.labelText), fieldConfig);
-
+            translateValidators(fieldConfig, d2);
+            setRequiredFieldsStepName(fieldConfig, modelType, d2);
+            setRequiredFieldsLabelText(fieldConfig, d2);
             return fieldConfig;
         }).concat(includeAttributes ? createAttributeFieldConfigs(d2, modelType) : []);
 }

--- a/src/forms/form-fields/drop-down-async.js
+++ b/src/forms/form-fields/drop-down-async.js
@@ -155,6 +155,7 @@ export default React.createClass({
                     options={this.state.options}
                     value={this.props.value ? this.props.value.id : undefined}
                     onChange={this._onChange}
+                    errorText={this.props.errorText}
                     fullWidth
                 />
                 {quickAddLink ?

--- a/src/forms/form-fields/drop-down.js
+++ b/src/forms/form-fields/drop-down.js
@@ -156,6 +156,7 @@ class Dropdown extends React.Component {
                     value={this.state.value}
                     fullWidth={fullWidth}
                     {...other}
+                    errorText={this.props.errorText}
                     onChange={this._onChange}
                     floatingLabelText={labelText}
                 >

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -457,6 +457,7 @@ organisation_unit_levels_save_success=Organisation unit levels saved!
 organisation_unit_levels_save_failed=Could not save organisation unit levels.
 no_roots_found=No roots found
 other_section=Other
+missing_required_property_field=Missing required property
 constant_management=Constant management
 constant=Constant
 intro_constant=Create constants which can be included in expressions of indicator and validation rules.


### PR DESCRIPTION
DHIS2-3588
Fix where user could not save any changes made to custom components in forms due to the "valid" prop in EditFormModel being set to false on default and not activating until all required fields where filled out. The reason for this not working is that many of the custom components do not notify the formBuilder onChange. And so the "valid" prop stay false and the save button remain disabled.

One would think that you would only need to add code to the onChange function of each components from formBuilder to fix it. But no.

The formBuilder binds the onChange function with the field-property name. This causes issues when the name of the field-property is the same as one of the subComponents. See e.g
SubjectMessageTemplateFields. This will cause all the other subComponents to also trigger changes on the field-property name at change.

So instead EditModelForms "valid" prop stays true and instead of relying on the formbuilder to post the form to the schema for validation, now validation is done when the user click Save. If the form is not valid, the snackBar will tell them and the save action is canceled.

This should work for all forms that uses EditModelForm. Validation does not work for programIndicators and programs as these create their own forms and doesn't have access to the formBuilder.

Added a function in EditField.saveAction to validate fields before saving and present the snackBar with what required field was invalid.

Added a setRequiredFieldsStepName in formHelpers that will add the name of the step a field is on. This will later be used to present the user with a helpful snackBar message on what step/group a required invalid field is on.

Added the translatedLabelName to fieldConfigs. For error validation snackBar message

Added functions in fields-groups to get a fields step belonging.

Added errorValidation texts to SubjectMessageTemplateFields and drop dows fields.