### PR TITLE
DHIS2-3547 Fix/v29 validation on save

### DIFF
--- a/src/EditModel/FormActionButtons.js
+++ b/src/EditModel/FormActionButtons.js
@@ -13,11 +13,10 @@ const styles = {
     },
 };
 
-// TODO: Make the isValid prop actually useful..
 export default function FormActionButtons({ onSaveAction, onCancelAction, isDirtyHandler, isSaving }) {
     return (
         <div>
-            <SaveButton onClick={onSaveAction} isValid isSaving={isSaving} />
+            <SaveButton onClick={onSaveAction} isSaving={isSaving} />
             <CancelButton onClick={onCancelAction} isDirtyHandler={isDirtyHandler} style={styles.cancelButton} />
         </div>
     );

--- a/src/EditModel/SaveButton.component.js
+++ b/src/EditModel/SaveButton.component.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+
 import RaisedButton from 'material-ui/RaisedButton/RaisedButton';
 import addD2Context from 'd2-ui/lib/component-helpers/addD2Context';
 
@@ -17,9 +19,10 @@ function SaveButton(props, { d2 }) {
 }
 
 SaveButton.propTypes = {
-    isSaving: React.PropTypes.bool,
-    isValid: React.PropTypes.bool,
-    onClick: React.PropTypes.func.isRequired,
+    isSaving: PropTypes.bool,
+    isValid: PropTypes.bool,
+    onClick: PropTypes.func.isRequired,
 };
+SaveButton.defaultProps = { isSaving: false, isValid: true };
 
 export default addD2Context(SaveButton);

--- a/src/EditModel/form-helpers/validateFields.js
+++ b/src/EditModel/form-helpers/validateFields.js
@@ -1,0 +1,66 @@
+import { get, find } from 'lodash/fp';
+
+/* *
+ * The result coming from FormBuilder validateField will contain an error message on fail and 
+ * a boolean true if it succeeds. This 
+ */
+const isInvalidField = validatedResult => validatedResult !== true;
+
+const isRequiredField = field => get('isRequired', field.fieldOptions) === true;
+
+const validateField = (field, formRef, formRefStateClone) => {
+    const validateResult = formRef.validateField(formRefStateClone, field.name, field.value);
+    return {
+        invalid: isInvalidField(validateResult),
+        step: field.step,
+        name: field.translatedName,
+    };
+};
+
+/* *
+ * Constructs the error message to present to the snackBar.
+ * Adds the step the field can be found on if present.
+ */
+const getErrorMessage = (field) => {
+    const fieldStep = field.step ? `On step ${field.step}` : '';
+
+    const errorMessage = `: ${field.name}. ${fieldStep}`;
+    return errorMessage;
+};
+
+/** 
+ * Will filter out all the fields that are required. 
+ * The it will validate the fields using the formBuilder
+ * and lastly fetch the first field that is required and invalid.
+ */
+const getFirstInvalidField = (fieldConfigs, formRef, formRefStateClone) =>
+    fieldConfigs
+        .filter(fieldConfig => isRequiredField(fieldConfig))
+        .map(fieldConfig => validateField(fieldConfig, formRef, formRefStateClone))
+        .find(field => field.invalid);
+
+/**
+ * Validate checks all the fields that are marked as required in the form.
+ * The validation will set the fields as invalid in the formbuilder and set
+ * the new state of the form.
+ * 
+ * If any the required fields are not valid not it will create a message string 
+ * of the first invalid field.
+ * 
+ * @returns {string} 
+ * The name and step/group of the invalid field.
+ * If no invalid field, it will return an empty string.
+ */
+export default function getFirstInvalidFieldMessage(fieldConfigs, formRef) {
+    const formRefStateClone = formRef.getStateClone();
+
+    const firstInvalidField = getFirstInvalidField(fieldConfigs, formRef, formRefStateClone);
+
+    if (!firstInvalidField) {
+        return '';
+    }
+    formRef.setState(formRefStateClone);
+
+    const errorMessage = getErrorMessage(firstInvalidField);
+    return errorMessage;
+}

--- a/src/config/field-config/field-groups.js
+++ b/src/config/field-config/field-groups.js
@@ -1,3 +1,4 @@
+import { findIndex } from 'lodash/fp';
 import fieldOrder from './field-order';
 
 /*
@@ -100,7 +101,7 @@ const fieldGroupsForModelType = new Map([
 
 export default {
     for(modelType) {
-        if (modelType && fieldGroupsForModelType.has(modelType)) {
+        if (this.isGroupedFields(modelType)) {
             return fieldGroupsForModelType.get(modelType);
         }
 
@@ -112,14 +113,34 @@ export default {
         ];
     },
 
+    isGroupedFields(modelType) {
+        return modelType && fieldGroupsForModelType.has(modelType);
+    },
+
+    groupNoByName(fieldName, modelType) {
+        if (this.isGroupedFields(modelType)) {
+            const modelGroup = fieldGroupsForModelType.get(modelType);
+            return findIndex((group => group.fields.includes(fieldName)), modelGroup);
+        }
+        return 0;
+    },
+
+    groupNameByStep(stepNo, modelType) {
+        if (this.isGroupedFields(modelType)) {
+            const modelGroup = fieldGroupsForModelType.get(modelType);
+            return modelGroup[stepNo].label;
+        }
+        return '';
+    },
+
     groupsByField(modelType) {
-        if (modelType && fieldGroupsForModelType.has(modelType)) {
+        if (this.isGroupedFields(modelType)) {
             return fieldGroupsForModelType
                 .get(modelType)
-                .map(g => g.fields)
-                .reduce((o, f, s) => {
-                    f.forEach(x => (o[x] = s));
-                    return o;
+                .map(group => group.fields)
+                .reduce((fieldsWithStep, groupFields, stepNo) => {
+                    groupFields.map(field => fieldsWithStep[field] = stepNo);
+                    return fieldsWithStep;
                 }, {});
         }
     },

--- a/src/forms/form-fields/drop-down-async.js
+++ b/src/forms/form-fields/drop-down-async.js
@@ -181,6 +181,7 @@ class DropDownAsync extends Component {
                         {...other}
                         top={this.props.top}
                         options={this.state.options}
+                        errorText={this.props.errorText}
                         value={this.props.value ? this.props.value.id : this.props.value}
                         onChange={this.onChange}
                         fullWidth={fullWidth}

--- a/src/forms/form-fields/drop-down.js
+++ b/src/forms/form-fields/drop-down.js
@@ -111,6 +111,7 @@ class Dropdown extends Component {
                 value={this.state.value}
                 fullWidth={this.props.fullWidth}
                 {...other}
+                errorText={this.props.errorText}
                 onChange={this.onChange}
                 floatingLabelText={this.props.labelText}
             >

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -446,6 +446,7 @@ organisation_unit_section=Organisation unit
 category_section=Category
 href=Api URL
 actions=Actions
+missing_required_property_field=Missing required property
 move_$$ouCount$$_organisation_units=Move $$ouCount$$ organisation units
 successfully_moved_$$ouName$$=Successfully moved $$ouName$$
 failed_to_move_$$ouName$$_($$errorMessage$$)=Failed to move $$ouName$$ ($$errorMessage$$)


### PR DESCRIPTION
DHIS2-3588
Fix where user could not save any changes made to custom components in forms due to the "valid" prop in EditFormModel being set to false on default and not activating until all required fields where filled out. The reason for this not working is that many of the custom components do not notify the formBuilder onChange. And so the "valid" prop stay false and the save button remain disabled.

One would think that you would only need to add code to the onChange function of each components from formBuilder to fix it. But no.

The formBuilder binds the onChange function with the field-property name. This causes issues when the name of the field-property is the same as one of the subComponents. See e.g
SubjectMessageTemplateFields. This will cause all the other subComponents to also trigger changes on the field-property name at change.

So instead EditModelForms "valid" prop stays true and instead of relying on the formbuilder to post the form to the schema for validation, now validation is done when the user click Save. If the form is not valid, the snackBar will tell them and the save action is canceled.

This should work for all forms that uses EditModelForm. Validation does not work for programIndicators and programs as these create their own forms and doesn't have access to the formBuilder.

Added a function in EditField.saveAction to validate fields before saving and present the snackBar with what required field was invalid.

Added a setRequiredFieldsStepName in formHelpers that will add the name of the step a field is on. This will later be used to present the user with a helpful snackBar message on what step/group a required invalid field is on.

Added the translatedLabelName to fieldConfigs. For error validation snackBar message

Added functions in fields-groups to get a fields step belonging.

Added errorValidation texts to SubjectMessageTemplateFields and drop dows fields.