### PR TITLE
Add preloadstate loader to routes

### DIFF
--- a/src/EditModel/EditDataSetSections.component.js
+++ b/src/EditModel/EditDataSetSections.component.js
@@ -47,8 +47,10 @@ class EditDataSetSections extends Component {
                 { fields: 'id,displayName', paging: false },
             ),
         ]).then(([catComboList]) => {
+            const sections = modelToEditStore.state.sections;
+            const sectionArray = Array.isArray(sections) ? sections : sections.toArray();
             this.setState({
-                sections: modelToEditStore.state.sections.toArray().sort((a, b) => a.sortOrder - b.sortOrder),
+                sections: sectionArray.sort((a, b) => a.sortOrder - b.sortOrder),
                 categoryCombos: catComboList.categoryCombos.map(cc => ({
                     value: cc.id,
                     text: cc.displayName === 'default' ? this.getTranslation('none') : cc.displayName,

--- a/src/List/List.component.js
+++ b/src/List/List.component.js
@@ -162,11 +162,10 @@ class List extends Component {
 
         const sourceStoreDisposable = listStore
             .subscribe((listStoreValue) => {
-                if (!isIterable(listStoreValue.list)) {
-                    return; // Received value is not iterable, keep waiting
+                if (!isIterable(listStoreValue.list) || listStoreValue.modelType !== this.props.params.modelType) {
+                    return; // Received value is not iterable or not correct model, keep waiting
                 }
                 listActions.hideDetailsBox();
-
                 this.setState({
                     dataRows: listStoreValue.list,
                     pager: listStoreValue.pager,
@@ -516,7 +515,6 @@ class List extends Component {
                 });
             }
         };
-
         return (
             <div>
                 <div>

--- a/src/List/SearchBox.component.js
+++ b/src/List/SearchBox.component.js
@@ -2,17 +2,15 @@ import React from 'react';
 import ObservedEvents from '../utils/ObservedEvents.mixin';
 import Translate from 'd2-ui/lib/i18n/Translate.mixin';
 import TextField from 'material-ui/TextField/TextField';
-import { config } from 'd2/lib/d2';
 import { currentSubSection$ } from '../App/appStateStore';
+import { withRouter } from 'react-router';
 
-const unsearchableSections = [
-    'organisationUnit',
-];
+const unsearchableSections = ['organisationUnit'];
 
 const SearchBox = React.createClass({
     propTypes: {
         searchObserverHandler: React.PropTypes.func.isRequired,
-        initialValue: React.PropTypes.string
+        initialValue: React.PropTypes.string,
     },
 
     mixins: [ObservedEvents, Translate],
@@ -28,22 +26,40 @@ const SearchBox = React.createClass({
         this.searchBoxCb = this.createEventObserver('searchBox');
     },
 
+    componentWillReceiveProps(nextProps) {
+        // Searchbox is not remounted when switching sections,
+        // Clear the value when this happens
+        if (this.props.params.modelType !== nextProps.params.modelType) {
+            this.setState({
+                value: '',
+            });
+        }
+    },
+
     componentDidMount() {
         const searchObserver = this.events.searchBox
             .debounceTime(400)
-            .map(event => event && event.target && event.target.value ? event.target.value : '')
+            .map(
+                event =>
+                    event && event.target && event.target.value
+                        ? event.target.value
+                        : ''
+            )
             .distinctUntilChanged();
 
         this.props.searchObserverHandler(searchObserver);
-
-        this.subscription = currentSubSection$
-            .subscribe(currentSection => this.setState({
+        this.subscription = currentSubSection$.subscribe(currentSection =>
+            this.setState({
+                ...this.state,
                 showSearchField: !unsearchableSections.includes(currentSection),
-            }));
+            })
+        );
     },
 
     componentWillUnmount() {
-        this.subscription && this.subscription.unsubscribe && this.subscription.unsubscribe();
+        this.subscription &&
+            this.subscription.unsubscribe &&
+            this.subscription.unsubscribe();
     },
 
     render() {
@@ -61,7 +77,9 @@ const SearchBox = React.createClass({
                     fullWidth={false}
                     type="search"
                     onChange={this._onKeyUp}
-                    floatingLabelText={`${this.getTranslation('search_by_name')}`}
+                    floatingLabelText={`${this.getTranslation(
+                        'search_by_name'
+                    )}`}
                 />
             </div>
         ) : null;
@@ -75,4 +93,4 @@ const SearchBox = React.createClass({
     },
 });
 
-export default SearchBox;
+export default withRouter(SearchBox);

--- a/src/router.js
+++ b/src/router.js
@@ -3,6 +3,7 @@ import { Router, Route, IndexRoute, hashHistory, IndexRedirect } from 'react-rou
 
 import { getInstance } from 'd2/lib/d2';
 import log from 'loglevel';
+import noop from 'lodash/fp/noop';
 
 import modelToEditStore from './EditModel/modelToEditStore';
 import objectActions from './EditModel/objectActions';
@@ -17,8 +18,7 @@ import { loadEventProgram } from './EditModel/event-program/actions';
 import { loadProgramIndicator } from './EditModel/program-indicator/actions';
 import LoadableComponent, { LoadableWithPreloadedStore } from './utils/LoadableComponent';
 
-const noop = () => {};
-
+listStore.subscribe(state => console.log(state));
 function initState({ params }) {
     initAppState({
         sideBar: {
@@ -99,7 +99,7 @@ function loadObject({ params }, replace) {
     } else {
         objectActions.getObjectOfTypeById({ objectType: params.modelType, objectId: params.modelId })
             .subscribe(
-                () => {},
+                noop,
                 (errorMessage) => {
                     replace(`/list/${params.modelType}`);
                     snackActions.show({ message: errorMessage, action: 'ok' });

--- a/src/router.js
+++ b/src/router.js
@@ -18,8 +18,6 @@ import { loadEventProgram } from './EditModel/event-program/actions';
 import { loadProgramIndicator } from './EditModel/program-indicator/actions';
 import LoadableComponent, { LoadableWithLoaders } from './utils/LoadableComponent';
 
-listStore.subscribe(val => console.log(val));
-
 function initState({ params }) {
     initAppState({
         sideBar: {
@@ -161,7 +159,6 @@ function loadList({ params }, replace) {
         return;
     }
     initState({ params });
-   // listStore.setState({isLoading: true})
     return listActions.loadList(params.modelType)
         .take(1)
         .subscribe(

--- a/src/router.js
+++ b/src/router.js
@@ -19,6 +19,7 @@ import { loadProgramIndicator } from './EditModel/program-indicator/actions';
 import LoadableComponent, { LoadableWithPreloadedStore } from './utils/LoadableComponent';
 
 listStore.subscribe(state => console.log(state));
+
 function initState({ params }) {
     initAppState({
         sideBar: {
@@ -59,8 +60,9 @@ function initStateOuHierarchy() {
 // to load the correct d2.Model. This would clean up the load function
 // below.
 function loadObject({ params }, replace) {
+    console.log("LOAD OBJECT")
     initState({ params });
-
+    const cb = noop;
     if (params.modelId === 'add') {
         getInstance().then((d2) => {
             const modelToEdit = d2.models[params.modelType].create();
@@ -81,6 +83,7 @@ function loadObject({ params }, replace) {
                         }
 
                         modelToEditStore.setState(modelToEdit);
+                        cb();
                     });
             }
 
@@ -95,11 +98,12 @@ function loadObject({ params }, replace) {
                 }, {});
 
             modelToEditStore.setState(Object.assign(modelToEdit, listFilters));
+            cb();
         });
     } else {
         objectActions.getObjectOfTypeById({ objectType: params.modelType, objectId: params.modelId })
             .subscribe(
-                noop,
+                () => { console.log("OBJECT LOADED"); cb() },
                 (errorMessage) => {
                     replace(`/list/${params.modelType}`);
                     snackActions.show({ message: errorMessage, action: 'ok' });
@@ -152,7 +156,7 @@ function loadList({ params }, replace) {
         // reflected in the organisation unit tree
         initState({ params });
     }
-
+    listStore.setState({});
     initState({ params });
     return listActions.loadList(params.modelType)
         .take(1)

--- a/src/utils/LoadableComponent.js
+++ b/src/utils/LoadableComponent.js
@@ -2,6 +2,9 @@ import React from 'react';
 import Loadable from 'react-loadable';
 import LoadingMask from '../loading-mask/LoadingMask.component';
 import modelToEditStore from '../EditModel/modelToEditStore';
+import listStore from '../List/list.store';
+
+modelToEditStore.subscribe(state => console.log('modeltoEditStore: ', state));
 
 const LoadableComponent = opts =>
     Loadable({
@@ -10,12 +13,82 @@ const LoadableComponent = opts =>
     });
 
 export default LoadableComponent;
-
 export const LoadableMap = opts =>
     Loadable.Map({
         loading: LoadingMask,
         ...opts,
     });
+
+const LoaderHackzorz = opts => {
+    const LoadedComponent = LoadableComponent(opts);
+    //Handle loading of component here, as we do it once
+ /*   let loaded = null;
+    if (!loaded) {
+        const promise = opts.loader();
+        loaded = {
+            error: false,
+            loading: true,
+            loaded: null,
+        };
+        loaded.promise = promise
+            .then(loadedComp => {
+                loaded.loading = false;
+                loaded.comp = loadedComp.default;
+                console.log(loadedComp);
+                console.log(loaded.comp)
+                return loaded.comp;
+            })
+            .catch(err => {
+                loaded.loading = false;
+                loaded.error = err;
+                return err;
+            });
+    } */
+    return class LoaderHack extends React.Component {
+        constructor(props) {
+            super(props);
+            this.state = {
+                loading: true, //loading of extra promises
+                component: null,
+                error: false,
+            };
+        }
+
+        componentWillMount() {
+            const promise = modelToEditStore
+                .filter(
+                    state =>
+                        state.sections && state.id === this.props.params.modelId
+                )
+                .take(1)
+                .toPromise();
+
+            promise.then(state => {
+                console.log('haczors,state', state);
+                this.setState({ loading: false });
+            });
+            /*
+            loaded.promise
+                .then(comp =>
+                    this.setState({component: comp, error: false })
+                )
+                .catch(err =>
+                    this.setState({
+                        error: loaded.error,
+                        loaded: null,
+                        loading: false,
+                    })
+                ); */
+        }
+
+        render() {
+            if(!this.state.loading) {
+                return <LoadedComponent {...this.props} />
+            }  
+            return <LoadingMask />
+        }
+    };
+};
 
 /**
  * A HOC that dynamically loads a component, and ensures modelToEditStore.state being available.
@@ -30,15 +103,29 @@ export const LoadableMap = opts =>
      'loader': a function with the import() statement.
 
  */
-export const LoadableWithPreloadedStore = ({ loader: load, ...rest }) =>
-    LoadableMap({
+export const LoadableWithPreloadedStore = ({ loader: load, ...rest }) => {
+    console.log('rest', rest);
+    return LoaderHackzorz({ loader: load });
+    return LoadableMap({
         loader: {
             Comp: load,
-            predefinedStore: () => modelToEditStore.take(1).toPromise(),
+            predefinedStore: () =>
+                (() => {
+                    console.log('predefinedstore');
+                    return modelToEditStore.take(1).toPromise();
+                })(),
+            /*listStore: () => {
+                console.log('takeWhile!');
+                return modelToEditStore
+                    .takeWhile(state => !state.sections)
+                    .toPromise();
+            },*/
         },
         render(loaded, props) {
+            console.log('render loadable!');
             const Comp = loaded.Comp.default;
             return <Comp {...props} />;
         },
         ...rest,
     });
+};

--- a/src/utils/LoadableComponent.js
+++ b/src/utils/LoadableComponent.js
@@ -45,11 +45,23 @@ export const LoadableWithLoaders = (loadableOpts, loaders) => {
             if (typeof loaders === 'function') {
                 loaders = [loaders];
             }
+        }
 
-            Promise.all(loaders.map(loader => loader(this.props)))
+        componentDidMount() {
+            this.runLoaders();
+        }
+        componentWillReceiveProps(nextProps) {
+            // reload when switching sections
+            if (nextProps.params.modelType !== this.props.params.modelType) {
+                this.runLoaders(nextProps);
+            }
+        }
+
+        runLoaders = (propsToUse = this.props) => {
+            Promise.all(loaders.map(loader => loader(propsToUse)))
                 .then(() => this.setState({ loading: false }))
                 .catch(error => this.setState({ error }));
-        }
+        };
 
         render() {
             if (!this.state.loading && !this.state.error) {

--- a/src/utils/LoadableComponent.js
+++ b/src/utils/LoadableComponent.js
@@ -26,8 +26,8 @@ export const LoadableMap = opts =>
     LoadableMap does not complete the loading before both "Comp" (the dynamic-loaded component)
     and predefinedStore-promises resolve.
 
-    @params {object} A react-loadable options object. The loader a function with the dynamic import() to import
-    the component.
+    @params {object} A react-loadable options object. The only required part of the object is
+     'loader': a function with the import() statement.
 
  */
 export const LoadableWithPreloadedStore = ({ loader: load, ...rest }) =>

--- a/src/utils/LoadableComponent.js
+++ b/src/utils/LoadableComponent.js
@@ -18,15 +18,19 @@ export const LoadableMap = opts =>
     });
 
 /**
- *  Due to removing async routes, and some routes depending on ModelToEditStore.state being available,
+ * A HOC that dynamically loads a component, and ensures modelToEditStore.state being available.
+ * Due to removing async routes, and some routes depending on ModelToEditStore.state being available,
     we have a loadable-component-HOC that also makes sure the modelToEditStore is initialized. 
     Preventing race conditions.
 
-    LoadableMap does complete the loading before both "Comp" (the dynamic-loaded component)
+    LoadableMap does not complete the loading before both "Comp" (the dynamic-loaded component)
     and predefinedStore-promises resolve.
 
+    @params {object} A react-loadable options object. The loader a function with the dynamic import() to import
+    the component.
+
  */
-export const LoadableWithPreloadedStore = ({ loader: load }) =>
+export const LoadableWithPreloadedStore = ({ loader: load, ...rest }) =>
     LoadableMap({
         loader: {
             Comp: load,
@@ -36,4 +40,5 @@ export const LoadableWithPreloadedStore = ({ loader: load }) =>
             const Comp = loaded.Comp.default;
             return <Comp {...props} />;
         },
+        ...rest,
     });

--- a/src/utils/LoadableComponent.js
+++ b/src/utils/LoadableComponent.js
@@ -1,9 +1,39 @@
-import LoadingMask from "../loading-mask/LoadingMask.component";
+import React from 'react';
 import Loadable from 'react-loadable';
+import LoadingMask from '../loading-mask/LoadingMask.component';
+import modelToEditStore from '../EditModel/modelToEditStore';
 
-const LoadableComponent = opts => Loadable({
-    loading: LoadingMask,
-    ...opts
-});
+const LoadableComponent = opts =>
+    Loadable({
+        loading: LoadingMask,
+        ...opts,
+    });
 
 export default LoadableComponent;
+
+export const LoadableMap = opts =>
+    Loadable.Map({
+        loading: LoadingMask,
+        ...opts,
+    });
+
+/**
+ *  Due to removing async routes, and some routes depending on ModelToEditStore.state being available,
+    we have a loadable-component-HOC that also makes sure the modelToEditStore is initialized. 
+    Preventing race conditions.
+
+    LoadableMap does complete the loading before both "Comp" (the dynamic-loaded component)
+    and predefinedStore-promises resolve.
+
+ */
+export const LoadableWithPreloadedStore = ({ loader: load }) =>
+    LoadableMap({
+        loader: {
+            Comp: load,
+            predefinedStore: () => modelToEditStore.take(1).toPromise(),
+        },
+        render(loaded, props) {
+            const Comp = loaded.Comp.default;
+            return <Comp {...props} />;
+        },
+    });


### PR DESCRIPTION
This fixes a number of issues.

When switching to dynamic loading with react-loadable, there was some issues with race conditions when changing routes, and the loading status in the list-component.
This is fixed by removing async-routes, as that fired the onLoad two times for each route change, being the origin of the race condition.

Some components use modelToEditStore.state directly, and may do so without checking if its initialised in the constructor. Therefore, I've added a HOC that checks for this together with loading the components. 

This should fix: https://jira.dhis2.org/browse/DHIS2-2683