### PR TITLE
Clear created-date when cloning objects

### DIFF
--- a/src/EditModel/SingleModelStore.js
+++ b/src/EditModel/SingleModelStore.js
@@ -135,6 +135,8 @@ const singleModelStoreConfig = {
                 model.id = undefined;
                 // Some objects also have a uuid property that should be cleared
                 model.uuid = undefined;
+                //let server handle created date
+                model.created = undefined;
                 model = cloneHandlerByObjectType(objectType, model);
                 this.setState(model);
             });


### PR DESCRIPTION
Should fix this: https://jira.dhis2.org/browse/DHIS2-3611 along with all other objects, as it did not clear the created date.