### PR TITLE
Add Event Program as default programType

### DIFF
--- a/src/EditModel/event-program/epics.js
+++ b/src/EditModel/event-program/epics.js
@@ -126,9 +126,10 @@ function loadEventProgramMetadataByProgramId(programPayload) {
             .map((state) => {
                 // Set some eventProgram defaults
                 // Set programType to router-query type
-                const programType = programPayload.query.type;
+                // fallback to event program
+                const programType = programPayload.query.type || "WITHOUT_REGISTRATION";
 
-                state.program.programType = programPayload.query.type;
+                state.program.programType = programType;
                 if (state.programStages.length > 0) {
                     const programStage = first(state.programStages);
                     programStage.name = state.program.id;


### PR DESCRIPTION
When following a route without the query param for programType, the programType was not set properly. It will now default to "WITHOUT_REGISTRATION" (programType).

Partial fix for https://jira.dhis2.org/browse/DHIS2-3579