### PR TITLE
DHIS2-35900 v28 backport of disappearing orgUnitFilter

### DIFF
--- a/src/forms/form-fields/orgunit-tree-multi-select.js
+++ b/src/forms/form-fields/orgunit-tree-multi-select.js
@@ -1,38 +1,79 @@
-import React from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Observable } from 'rxjs';
+
 import OrgUnitTree from 'd2-ui/lib/org-unit-tree/OrgUnitTreeMultipleRoots.component';
 import OrgUnitSelectByLevel from 'd2-ui/lib/org-unit-select/OrgUnitSelectByLevel.component';
 import OrgUnitSelectByGroup from 'd2-ui/lib/org-unit-select/OrgUnitSelectByGroup.component';
 import OrgUnitSelectAll from 'd2-ui/lib/org-unit-select/OrgUnitSelectAll.component';
 import TextField from 'material-ui/TextField/TextField';
-import Action from 'd2-ui/lib/action/Action';
-import { Observable } from 'rxjs';
 
-export default class OrganisationUnitTreeMultiSelect extends React.Component {
+import Action from 'd2-ui/lib/action/Action';
+
+const styles = {
+    multiSelectWrapper: {
+        position: 'relative',
+        minWidth: 850,
+    },
+    selectAllWrapper: {
+        marginTop: 16,
+    },
+    controlStyles: {
+        width: 475,
+        zIndex: 1,
+        background: 'white',
+        marginLeft: '1rem',
+        marginTop: '1rem',
+        display: 'inline-block',
+    },
+    controlOverlayStyles: {
+        position: 'absolute',
+        width: 495,
+        height: 240,
+        marginLeft: -10,
+        marginTop: 4,
+        backgroundColor: 'rgba(230,230,230,0.3)',
+        zIndex: 2,
+        borderRadius: 8,
+    },
+    currentRootStyle: {
+        border: '1px solid rgba(0,0,0,0.1)',
+        borderRadius: 3,
+        backgroundColor: 'rgba(0,0,0,0.05)',
+        padding: 2,
+        margin: 4,
+    },
+    treeWrapperStyle: {
+        minHeight: 300,
+        maxHeight: 450,
+        minWidth: 350,
+        maxWidth: 480,
+        overflow: 'auto',
+        border: '1px solid #bdbdbd',
+        borderRadius: 3,
+        padding: 4,
+        margin: '4px 0',
+        display: 'inline-block',
+        verticalAlign: 'top',
+    },
+};
+
+export default class OrganisationUnitTreeMultiSelect extends Component {
     constructor(...args) {
         super(...args);
 
         this.state = {
+            isLoading: true,
             searchValue: '',
             rootOrgUnits: [],
             selectedOrgUnits: [],
         };
 
-        this._searchOrganisationUnits = Action.create('searchOrganisationUnits');
-
-        this._handleClick = this._handleClick.bind(this);
-        this._setSelection = this._setSelection.bind(this);
+        this.searchOrganisationUnits = Action.create('searchOrganisationUnits');
     }
 
     componentDidMount() {
         const d2 = this.context.d2;
-
-        const overlyComplicatedTemporaryFixForWeirdlyNamedFields = (plural) => {
-            if (plural === 'organisationUnitGroups') {
-                return 'groups';
-            }
-
-            return plural;
-        };
 
         Promise.all([
             d2.currentUser.getOrganisationUnits({
@@ -56,9 +97,9 @@ export default class OrganisationUnitTreeMultiSelect extends React.Component {
                 const rootOrgUnits = orgUnits
                     .toArray()
                     .filter(ou => (new RegExp(`${this.state.searchValue}`)).test(ou.displayName));
-
                 this.setState({
                     originalRoots: rootOrgUnits,
+                    isLoading: false,
                     rootOrgUnits,
                     currentRoot: rootOrgUnits[0],
                     selectedOrgUnits: this.props.value.toArray().map(ou => ou.path),
@@ -67,18 +108,21 @@ export default class OrganisationUnitTreeMultiSelect extends React.Component {
                 });
             });
 
-        this.subscription = this._searchOrganisationUnits.map(action => action.data)
+        this.subscription = this.searchOrganisationUnits.map(action => action.data)
             .debounceTime(400)
             .map((searchValue) => {
                 if (!searchValue.trim()) {
                     return Observable.of(this.state.originalRoots);
                 }
-
                 const organisationUnitRequest = this.context.d2.models.organisationUnits
                     .filter().on('displayName').ilike(searchValue)
                     // withinUserHierarchy makes the query only apply to the subtrees of the organisation units that are
                     // assigned to the current user
-                    .list({ fields: 'id,displayName,path,children::isNotEmpty', withinUserHierarchy: true })
+                    .list({
+                        pageSize: 100,
+                        fields: 'id,displayName,path,children::isNotEmpty',
+                        withinUserHierarchy: true,
+                    })
                     .then(modelCollection => modelCollection.toArray());
 
                 return Observable.fromPromise(organisationUnitRequest);
@@ -91,129 +135,7 @@ export default class OrganisationUnitTreeMultiSelect extends React.Component {
         this.subscription && this.subscription.unsubscribe();
     }
 
-    renderRoots() {
-        const treeWrapperStyle = {
-            minHeight: 300,
-            maxHeight: 450,
-            minWidth: 350,
-            maxWidth: 480,
-            overflow: 'auto',
-            border: '1px solid #bdbdbd',
-            borderRadius: 3,
-            padding: 4,
-            margin: '4px 0',
-            display: 'inline-block',
-            verticalAlign: 'top',
-        };
-
-        return (
-            <div style={treeWrapperStyle}>
-                {this.state.rootOrgUnits.length
-                    ? this.state.rootOrgUnits.map(rootOu => (
-                        <OrgUnitTree
-                            key={rootOu.id}
-                            root={rootOu}
-                            selected={this.state.selectedOrgUnits}
-                            onSelectClick={this._handleClick}
-                            currentRoot={this.state.currentRoot}
-                            onChangeCurrentRoot={currentRoot => this.setState({ currentRoot })}
-                            initiallyExpanded={[rootOu.path]}
-                        />
-                    ))
-                    : (<div>{this.context.d2.i18n.getTranslation('no_roots_found')}</div>)
-                }
-            </div>
-        );
-    }
-
-    render() {
-        if (!this.state.rootOrgUnits.length) {
-            return (<div>{this.context.d2.i18n.getTranslation('determining_your_root_orgunits')}</div>);
-        }
-
-        const controlStyles = {
-            width: 475,
-            zIndex: 1,
-            background: 'white',
-            marginLeft: '1rem',
-            marginTop: '1rem',
-            display: 'inline-block',
-        };
-        const helpStyles = {
-            width: 475,
-            zIndex: 1,
-            background: 'white',
-            marginLeft: '1rem',
-            marginTop: '1rem',
-            verticalAlign: 'middle',
-            display: 'inline-block',
-            color: 'rgba(0,0,0,0.5)',
-        };
-        const controlOverlayStyles = this.state.currentRoot ? {} : {
-            position: 'absolute',
-            width: 495,
-            height: 240,
-            marginLeft: -10,
-            marginTop: 4,
-            backgroundColor: 'rgba(230,230,230,0.3)',
-            zIndex: 2,
-            borderRadius: 8,
-        };
-        const currentRootStyle = {
-            border: '1px solid rgba(0,0,0,0.1)',
-            borderRadius: 3,
-            backgroundColor: 'rgba(0,0,0,0.05)',
-            padding: 2,
-            margin: 4,
-        };
-
-        return (
-            <div style={{ position: 'relative', minWidth: 850 }}>
-                <TextField
-                    onChange={event => this._searchOrganisationUnits(event.target.value)}
-                    floatingLabelText={this.context.d2.i18n.getTranslation('filter_organisation_units_by_name')}
-                    fullWidth
-                />
-                <div className="organisation-unit-tree__selected">{this.state.selectedOrgUnits.length} {this.context.d2.i18n.getTranslation('organisation_units_selected')}</div>
-                {this.renderRoots()}
-                {this.state.orgUnitGroups && this.state.orgUnitLevels && (
-                    <div style={controlStyles}>
-                        {this.state.currentRoot
-                            ? (
-                                <span>{this.context.d2.i18n.getTranslation('for_organisation_units_within')}
-                                    <span style={currentRootStyle}>{this.state.currentRoot.displayName}</span>:
-                                </span>
-                            ) : (
-                                <span>{this.context.d2.i18n.getTranslation('select_a_parent_organisation_unit')}</span>
-                            )
-                        }
-                        <div style={controlOverlayStyles} />
-                        <OrgUnitSelectByLevel
-                            levels={this.state.orgUnitLevels}
-                            selected={this.state.selectedOrgUnits}
-                            currentRoot={this.state.currentRoot}
-                            onUpdateSelection={this._setSelection}
-                        />
-                        <OrgUnitSelectByGroup
-                            groups={this.state.orgUnitGroups}
-                            selected={this.state.selectedOrgUnits}
-                            currentRoot={this.state.currentRoot}
-                            onUpdateSelection={this._setSelection}
-                        />
-                        <div style={{ marginTop: 16 }}>
-                            <OrgUnitSelectAll
-                                selected={this.state.selectedOrgUnits}
-                                currentRoot={this.state.currentRoot}
-                                onUpdateSelection={this._setSelection}
-                            />
-                        </div>
-                    </div>
-                )}
-            </div>
-        );
-    }
-
-    _setSelection(selectedOrgUnitPaths) {
+    setSelection = (selectedOrgUnitPaths) => {
         const d2 = this.context.d2;
 
         const selectedOrgUnitIds = selectedOrgUnitPaths.map(path => path.substr(path.lastIndexOf('/') + 1));
@@ -242,7 +164,7 @@ export default class OrganisationUnitTreeMultiSelect extends React.Component {
         this.setState({ selectedOrgUnits: selectedOrgUnitPaths });
     }
 
-    _handleClick(event, orgUnit) {
+    handleClick = (event, orgUnit) => {
         if (this.state.selectedOrgUnits.includes(orgUnit.path)) {
             this.setState((state) => {
                 state.selectedOrgUnits.splice(state.selectedOrgUnits.indexOf(orgUnit.path), 1);
@@ -261,11 +183,91 @@ export default class OrganisationUnitTreeMultiSelect extends React.Component {
             });
         }
     }
+
+    renderOrganisationUnitTree() {
+        return (
+            <div style={styles.treeWrapperStyle}>
+                {this.state.rootOrgUnits.length
+                    ? this.state.rootOrgUnits.map(rootOu => (
+                        <OrgUnitTree
+                            key={rootOu.id}
+                            root={rootOu}
+                            selected={this.state.selectedOrgUnits}
+                            onSelectClick={this.handleClick}
+                            currentRoot={this.state.currentRoot}
+                            onChangeCurrentRoot={currentRoot => this.setState({ currentRoot })}
+                            initiallyExpanded={[rootOu.path]}
+                        />
+                    ))
+                    : (<div>{this.context.d2.i18n.getTranslation('no_roots_found')}</div>)
+                }
+            </div>
+        );
+    }
+
+    renderSelectorButtons() {
+        return (
+            this.state.orgUnitGroups && this.state.orgUnitLevels &&
+            <div style={styles.controlStyles} >
+                {this.state.currentRoot
+                    ? (
+                        <span>{this.context.d2.i18n.getTranslation('for_organisation_units_within')}
+                            <span style={styles.currentRootStyle}>{this.state.currentRoot.displayName}</span>
+                        </span>
+                    ) : (
+                        <span>{this.context.d2.i18n.getTranslation('select_a_parent_organisation_unit')}</span>
+                    )
+                }
+                <div style={this.state.currentRoot ? {} : styles.controlOverlayStyles} />
+                <OrgUnitSelectByLevel
+                    levels={this.state.orgUnitLevels}
+                    selected={this.state.selectedOrgUnits}
+                    currentRoot={this.state.currentRoot}
+                    onUpdateSelection={this.setSelection}
+                />
+                <OrgUnitSelectByGroup
+                    groups={this.state.orgUnitGroups}
+                    selected={this.state.selectedOrgUnits}
+                    currentRoot={this.state.currentRoot}
+                    onUpdateSelection={this.setSelection}
+                />
+                <div style={styles.selectAllWrapper}>
+                    <OrgUnitSelectAll
+                        selected={this.state.selectedOrgUnits}
+                        currentRoot={this.state.currentRoot}
+                        onUpdateSelection={this.setSelection}
+                    />
+                </div>
+            </div>
+        );
+    }
+
+    render() {
+        if (this.state.isLoading) {
+            return (<div>{this.context.d2.i18n.getTranslation('determining_your_root_orgunits')}</div>);
+        }
+        return (
+            <div style={styles.multiSelectWrapper}>
+                <TextField
+                    onChange={event => this.searchOrganisationUnits(event.target.value)}
+                    floatingLabelText={this.context.d2.i18n.getTranslation('filter_organisation_units_by_name')}
+                    fullWidth
+                />
+                <div className="organisation-unit-tree__selected">
+                    {this.state.selectedOrgUnits.length} {this.context.d2.i18n.getTranslation('organisation_units_selected')}
+                </div>
+                {this.renderOrganisationUnitTree()}
+                {this.renderSelectorButtons()}
+            </div>
+        );
+    }
 }
+
 OrganisationUnitTreeMultiSelect.contextTypes = {
     d2: React.PropTypes.object.isRequired,
 };
 OrganisationUnitTreeMultiSelect.propTypes = {
+    model: PropTypes.object.isRequired,
     value: React.PropTypes.object,
 };
 OrganisationUnitTreeMultiSelect.defaultProps = {


### PR DESCRIPTION
Linting

Moved inline styles to style object

Removed overlyComplicatedTemporaryFixForWeirdlyNamedFields. (was not even in use)

Increased the return results of filter search to 100

Fixed error where a empty return filter search would remove the component. The problem was that the component just returned a div with a string as soon as the rootOrgUnit array was empty. Effectively removing the filter bar in the process with no means to delete the search string to fill the rootOrgUnit array again. (line 130). The idea seemed to be that this would be used only to show the user while orgUnits was loading.

To fix this problem and the semantic clarity I added a isLoading state that starts out true and is set to false after orgUnits are loaded in componentDidMount.