### PR TITLE
Open downloads in new window/tab

### DIFF
--- a/src/SqlView/SqlView.component.js
+++ b/src/SqlView/SqlView.component.js
@@ -47,7 +47,7 @@ class SqlView extends Component {
     openFileLink(file) {
         const { params: { modelId } } = this.props;
         this.closeDownloadMenu();
-        window.location.href = `../api/sqlViews/${modelId}/${file}`;
+        window.open(`../api/sqlViews/${modelId}/${file}`, '_blank');
     }
 
     openDownloadMenu = (event) => {


### PR DESCRIPTION
If it opens in a new tab is a browser setting. Could also open in a new window. This behaviour cannot be controlled via JS