### PR TITLE
Removed onEnter property  from dataEntryForm route

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -269,7 +269,6 @@ const routes = (
                     path=":modelType/:modelId/dataEntryForm"
                     component={LoadableWithLoaders({ loader: () => import('./EditModel/EditDataEntryForm.component') },
                         loadObject)}
-                    onEnter={loadObject}
                     hideSidebar
                     disableTabs
                 />


### PR DESCRIPTION
We are calling loadObject in the component property already with the correct footprint.