### PR TITLE
Show parent when searching for leaf node

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@dhis2/d2-ui-sharing-dialog": "^1.0.12",
     "d2": "^29.1.3",
-    "d2-ui": "29.0.20",
+    "d2-ui": "29.0.21",
     "material-ui": "^0.17.0",
     "nyc": "10.1.2",
     "prop-types": "^15.6.0",

--- a/src/App/appStateStore.js
+++ b/src/App/appStateStore.js
@@ -69,7 +69,10 @@ async function getCurrentUserOrganisationUnits(disableCache = false) {
     }
 
     const d2 = await getInstance();
-    const organisationUnitsCollection = await d2.currentUser.getOrganisationUnits({ paging: false });
+    const organisationUnitsCollection = await d2.currentUser.getOrganisationUnits({
+        fields: ':all,access,displayName,path,children[id,displayName,path,children::isNotEmpty,access]',
+        paging: false
+    });
 
     if (d2.currentUser.authorities.has('ALL') && !organisationUnitsCollection.size) {
         const rootLevelOrgUnits = await d2.models.organisationUnits.list({
@@ -77,7 +80,7 @@ async function getCurrentUserOrganisationUnits(disableCache = false) {
             paging: false,
             fields: [
                 'id,displayName,path,publicAccess,access,lastUpdated',
-                'children[id,displayName,path,children::isNotEmpty]',
+                'children[id,displayName,publicAccess,access,path,children::isNotEmpty]',
             ].join(','),
         });
 

--- a/src/List/organisation-unit-list/OrganisationUnitList.component.js
+++ b/src/List/organisation-unit-list/OrganisationUnitList.component.js
@@ -35,13 +35,14 @@ export default class OrganisationUnitList extends React.Component {
                         .filter().on('parent.id').equals(selectedOrganisationUnit.id)
                         .list({ fields: fieldFilteringForQuery });
 
-                    // When a root organisation unit is selected we also add the root organisation unit to the list
-                    // of available organisation units to pick from
-                    if (userOrganisationUnitIds.indexOf(selectedOrganisationUnit.id) >= 0) {
-                        organisationUnitList.add(selectedOrganisationUnit);
-                    }
+                    // DHIS2-2160 Add the selected node to the list to
+                    // avoid having to select the parent node to edit
+                    // the selected node...
+                    let filteredOrgUnits = organisationUnitList.toArray();
+                    filteredOrgUnits.unshift(selectedOrganisationUnit);
+                    let prependedOrgUnitList = ModelCollection.create(d2.models.organisationUnit, filteredOrgUnits);
 
-                    listActions.setListSource(organisationUnitList);
+                    listActions.setListSource(prependedOrgUnitList);
                 },
                 error => log.error(error)
             );

--- a/src/OrganisationUnitHierarchy/searchForOrganisationUnitsWithinHierarchy.js
+++ b/src/OrganisationUnitHierarchy/searchForOrganisationUnitsWithinHierarchy.js
@@ -9,12 +9,13 @@ export default async function searchForOrganisationUnitsWithinHierarchy(searchVa
             id: ou.id,
             path: ou.path,
             displayName: ou.displayName,
+            access: ou.access,
         }));
     }
 
     const organisationUnitsThatMatchQuery = await d2.models.organisationUnits
         .list({
-            fields: 'id,parent[id,displayName,path,children],displayName,path,children::isNotEmpty',
+            fields: 'id,parent[id,displayName,path,children,access],displayName,path,children::isNotEmpty,access',
             query: searchValue,
             withinUserHierarchy: true,
             pageSize: limit,

--- a/src/OrganisationUnitHierarchy/searchForOrganisationUnitsWithinHierarchy.js
+++ b/src/OrganisationUnitHierarchy/searchForOrganisationUnitsWithinHierarchy.js
@@ -14,7 +14,7 @@ export default async function searchForOrganisationUnitsWithinHierarchy(searchVa
 
     const organisationUnitsThatMatchQuery = await d2.models.organisationUnits
         .list({
-            fields: 'id,displayName,path,children::isNotEmpty',
+            fields: 'id,parent[id,displayName,path,children],displayName,path,children::isNotEmpty',
             query: searchValue,
             withinUserHierarchy: true,
             pageSize: limit,

--- a/src/OrganisationUnitTree/OrganisationUnitTreeWithSingleSelectionAndSearch.component.js
+++ b/src/OrganisationUnitTree/OrganisationUnitTreeWithSingleSelectionAndSearch.component.js
@@ -27,19 +27,19 @@ function OrganisationUnitTreeWithSingleSelectionAndSearch(props, context) {
             {Array.isArray(props.roots) && props.roots.length > 0 ? props.roots
                 .map(root =>
                 {
-                    let parrot = root;
-                    if (parrot.parent) {
-                        parrot = context.d2.models.organisationUnits.create({
-                            id: parrot.parent.id,
-                            path: parrot.parent.path,
-                            displayName: parrot.parent.displayName,
+                    let treeRoot = root;
+                    if (treeRoot.parent) {
+                        treeRoot = context.d2.models.organisationUnits.create({
+                            id: treeRoot.parent.id,
+                            path: treeRoot.parent.path,
+                            displayName: treeRoot.parent.displayName,
                             children: [root]
                         });
                     }
                     return (
                         <OrganisationUnitTree
                             key={root.id}
-                            root={parrot}
+                            root={treeRoot}
                             selected={props.selected}
                             initiallyExpanded={props.initiallyExpanded}
                             labelStyle={styles.labelStyle}

--- a/src/OrganisationUnitTree/OrganisationUnitTreeWithSingleSelectionAndSearch.component.js
+++ b/src/OrganisationUnitTree/OrganisationUnitTreeWithSingleSelectionAndSearch.component.js
@@ -24,19 +24,32 @@ function OrganisationUnitTreeWithSingleSelectionAndSearch(props, context) {
                 dataSource={props.autoCompleteDataSource}
                 filter={AutoComplete.noFilter}
             />
-            {Array.isArray(props.roots) && props.roots.length > 0 ? props.roots.map(root => (
-                <OrganisationUnitTree
-                    key={root.id}
-                    root={root}
-                    selected={props.selected}
-                    initiallyExpanded={props.initiallyExpanded}
-                    labelStyle={styles.labelStyle}
-                    onSelectClick={props.onSelectClick}
-                    idsThatShouldBeReloaded={props.idsThatShouldBeReloaded}
-                    hideCheckboxes={props.hideCheckboxes}
-                    hideMemberCount={props.hideMemberCount}
-                />
-            )) : <div style={styles.noHitsLabel}>{props.noHitsLabel}</div>}
+            {Array.isArray(props.roots) && props.roots.length > 0 ? props.roots
+                .map(root =>
+                {
+                    let parrot = root;
+                    if (parrot.parent) {
+                        parrot = context.d2.models.organisationUnits.create({
+                            id: parrot.parent.id,
+                            path: parrot.parent.path,
+                            displayName: parrot.parent.displayName,
+                            children: [root]
+                        });
+                    }
+                    return (
+                        <OrganisationUnitTree
+                            key={root.id}
+                            root={parrot}
+                            selected={props.selected}
+                            initiallyExpanded={props.initiallyExpanded}
+                            labelStyle={styles.labelStyle}
+                            onSelectClick={props.onSelectClick}
+                            idsThatShouldBeReloaded={props.idsThatShouldBeReloaded}
+                            hideCheckboxes={props.hideCheckboxes}
+                            hideMemberCount={props.hideMemberCount}
+                        />
+                    )
+                }) : <div style={styles.noHitsLabel}>{props.noHitsLabel}</div>}
         </div>
     );
 }

--- a/src/OrganisationUnitTree/OrganisationUnitTreeWithSingleSelectionAndSearch.component.js
+++ b/src/OrganisationUnitTree/OrganisationUnitTreeWithSingleSelectionAndSearch.component.js
@@ -33,6 +33,7 @@ function OrganisationUnitTreeWithSingleSelectionAndSearch(props, context) {
                             id: treeRoot.parent.id,
                             path: treeRoot.parent.path,
                             displayName: treeRoot.parent.displayName,
+                            access: treeRoot.parent.access,
                             children: [root]
                         });
                     }

--- a/src/SideBar/SideBarContainer.component.js
+++ b/src/SideBar/SideBarContainer.component.js
@@ -59,6 +59,7 @@ class SideBarContainer extends React.Component {
                 };
 
                 const orgUnitSearchHits = appState.getState().sideBar.organisationUnits;
+
                 const roots = Array.isArray(orgUnitSearchHits)
                     ? orgUnitSearchHits
                     : this.state.userOrganisationUnits.toArray().map((ou) => {
@@ -71,6 +72,8 @@ class SideBarContainer extends React.Component {
 
                 const initiallyExpanded = this.getExpandedItems(orgUnitSearchHits);
 
+                const idsToReload = orgUnitSearchHits ? orgUnitSearchHits.reduce((x, y) => x.concat(y.id), []) : [];
+
                 return (
                     <div style={styles.wrapperStyle}>
                         <OrganisationUnitTreeWithSingleSelectionAndSearch
@@ -81,7 +84,7 @@ class SideBarContainer extends React.Component {
                             selected={this.state.selectedOrganisationUnit ? [this.state.selectedOrganisationUnit.path] : []}
                             initiallyExpanded={initiallyExpanded}
                             onSelectClick={this._onChangeSelectedOrgUnit.bind(this)}
-                            idsThatShouldBeReloaded={orgUnitSearchHits || this.state.organisationUnitsToReload}
+                            idsThatShouldBeReloaded={idsToReload || this.state.organisationUnitsToReload}
                             noHitsLabel={this.context.d2.i18n.getTranslation('no_matching_organisation_units')}
                             hideMemberCount
                             hideCheckboxes

--- a/yarn.lock
+++ b/yarn.lock
@@ -2211,9 +2211,9 @@ d2-manifest@^1.0.0-2:
     minimist "^1.1.0"
     readline-sync "^1.4.1"
 
-d2-ui@29.0.20:
-  version "29.0.20"
-  resolved "https://registry.yarnpkg.com/d2-ui/-/d2-ui-29.0.20.tgz#d9f1322a55607cf033f0763b04417eb1f93bce50"
+d2-ui@29.0.21:
+  version "29.0.21"
+  resolved "https://registry.yarnpkg.com/d2-ui/-/d2-ui-29.0.21.tgz#89f5cb810d58e11fa88cef2b3e8cb2ee261c5a06"
 
 d2-utilizr@^0.2.9:
   version "0.2.16"


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-2160

1. To avoid the problem where a user becomes "trapped" in a leaf node we can always show the parent in the search results
2. To avoid the problem where a user selects a leaf node and winds up with an empty list to the right, we can show the selected org unit in the list

The selected org unit is always shown in the right hand list, always at the top instead of at the bottom. Since the `modelCollection` is Map-backed some trickery is required (if you have a better idea let me know).

I patched d2-ui to retrieve the `access` field for children in the list. It's a bit annoying that some data is fetched through the component and some through the app. The app should ideally feed the component with data but this is the reality of the old d2-ui. New version is pushed to d2-ui@29.0.21.

Since I am using a home-grown root-node for the search result list I also need to add the fields required for the component to `treeRoot`. This is the minimum I could get away with since the component makes a lot of assumptions about the data passed in.