### PR TITLE
Remove clone in contextMenu for optionSet

### DIFF
--- a/src/List/List.component.js
+++ b/src/List/List.component.js
@@ -277,7 +277,7 @@ class List extends Component {
         case 'edit':
             return model.modelDefinition.name !== 'locale' && model.access.write;
         case 'clone':
-            return !['dataSet', 'program', 'locale', 'sqlView'].includes(model.modelDefinition.name) &&
+            return !['dataSet', 'program', 'locale', 'sqlView', 'optionSet'].includes(model.modelDefinition.name) &&
                 model.access.write;
         case 'translate':
             return model.access.read && model.modelDefinition.identifiableObject && model.modelDefinition.name !== 'sqlView';


### PR DESCRIPTION
Due to the severe bug, that cloning an optionSet MOVES all options to the cloned one, the ability to clone has been removed from the context-menu.

This should be fixed backend, and the model will be reworked to support many-to-many, which will simplify cloning.
