### PR TITLE
Dhis2 4197/incorrect render options when data element is added

### DIFF
--- a/src/EditModel/event-program/assign-data-elements/__tests__/epics.spec.js
+++ b/src/EditModel/event-program/assign-data-elements/__tests__/epics.spec.js
@@ -8,6 +8,9 @@ import {
 } from '../actions';
 import createEpicsForStore from '../epics';
 
+const availableDataElementA = { id: "eMyVanycQSC", displayName: "First available element", valueType: "INTEGER" };
+const availableDataElementB = { id: "d68jOejl9FI", displayName: "Second available element", valueType: "FILE_RESOURCE" };
+
 describe('Assign data elements epics', () => {
     const createActionStreamFor = action => ActionsObservable.of(action);
 
@@ -61,6 +64,10 @@ describe('Assign data elements epics', () => {
                     }],
                 },
             ],
+            availableDataElements: [
+                { ...availableDataElementA },
+                { ...availableDataElementB },
+            ]
         });
     });
 
@@ -81,9 +88,7 @@ describe('Assign data elements epics', () => {
                         const newlyAddedDataElement = store.getState().programStages[0].programStageDataElements[2];
 
                         expect(isValidUid(newlyAddedDataElement.id)).toBe(true);
-                        expect(newlyAddedDataElement.dataElement).toEqual({
-                            id: 'eMyVanycQSC',
-                        });
+                        expect(newlyAddedDataElement.dataElement).toEqual(availableDataElementA);
                         done();
                     },
                     done);
@@ -108,12 +113,8 @@ describe('Assign data elements epics', () => {
                         expect(isValidUid(newlyAddedDataElementOne.id)).toBe(true);
                         expect(isValidUid(newlyAddedDataElementTwo.id)).toBe(true);
 
-                        expect(newlyAddedDataElementOne.dataElement).toEqual({
-                            id: 'eMyVanycQSC',
-                        });
-                        expect(newlyAddedDataElementTwo.dataElement).toEqual({
-                            id: 'd68jOejl9FI',
-                        });
+                        expect(newlyAddedDataElementOne.dataElement).toEqual(availableDataElementA);
+                        expect(newlyAddedDataElementTwo.dataElement).toEqual(availableDataElementB);
                         done();
                     },
                     done

--- a/src/EditModel/event-program/assign-data-elements/__tests__/epics.spec.js
+++ b/src/EditModel/event-program/assign-data-elements/__tests__/epics.spec.js
@@ -88,7 +88,11 @@ describe('Assign data elements epics', () => {
                         const newlyAddedDataElement = store.getState().programStages[0].programStageDataElements[2];
 
                         expect(isValidUid(newlyAddedDataElement.id)).toBe(true);
-                        expect(newlyAddedDataElement.dataElement).toEqual(availableDataElementA);
+                        expect(newlyAddedDataElement.dataElement).toEqual({
+                            id: availableDataElementA.id,
+                            optionSet: availableDataElementA.optionSet,
+                            valueType: availableDataElementA.valueType,
+                        });
                         done();
                     },
                     done);
@@ -113,8 +117,16 @@ describe('Assign data elements epics', () => {
                         expect(isValidUid(newlyAddedDataElementOne.id)).toBe(true);
                         expect(isValidUid(newlyAddedDataElementTwo.id)).toBe(true);
 
-                        expect(newlyAddedDataElementOne.dataElement).toEqual(availableDataElementA);
-                        expect(newlyAddedDataElementTwo.dataElement).toEqual(availableDataElementB);
+                        expect(newlyAddedDataElementOne.dataElement).toEqual({
+                            id: availableDataElementA.id,
+                            optionSet: availableDataElementA.optionSet,
+                            valueType: availableDataElementA.valueType,
+                        });
+                        expect(newlyAddedDataElementTwo.dataElement).toEqual({
+                            id: availableDataElementB.id,
+                            optionSet: availableDataElementB.optionSet,
+                            valueType: availableDataElementB.valueType,
+                        });
                         done();
                     },
                     done

--- a/src/EditModel/event-program/assign-data-elements/epics.js
+++ b/src/EditModel/event-program/assign-data-elements/epics.js
@@ -59,11 +59,13 @@ const addDataElementsToStage = store => action$ =>
                 'payload.dataElements',
                 action
             );
+            console.log('ACTION ', action);
+            console.log('STATE', state)
             const programStageDataElementsToAdd = map(
                 id => ({
                     id: generateUid(),
                     dataElement: {
-                        id,
+                        ...state.availableDataElements.find(dataElement => dataElement.id === id),
                     },
                 }),
                 dataElementIdsToAdd

--- a/src/EditModel/event-program/assign-data-elements/epics.js
+++ b/src/EditModel/event-program/assign-data-elements/epics.js
@@ -42,37 +42,47 @@ const getProgramStageByIdFromAction = (store, action) => {
 const addDataElementsToStage = store => action$ =>
     action$
         .ofType(PROGRAM_STAGE_DATA_ELEMENTS_ADD)
-        .map(action => {
+        .map((action) => {
             const state = store.getState();
             const programStageToEdit = getProgramStageByIdFromAction(
                 store,
-                action
+                action,
             );
 
             const programStageDataElements = getOr(
                 [],
                 'programStageDataElements',
-                programStageToEdit
+                programStageToEdit,
             );
             const dataElementIdsToAdd = getOr(
                 [],
                 'payload.dataElements',
-                action
+                action,
             );
-            console.log('ACTION ', action);
-            console.log('STATE', state)
-            const programStageDataElementsToAdd = map(
-                id => ({
+            // TODO: Simplify this once JIRA issue DHIS2-4207 is done
+            // Currently simple saving failed for programStageDataElements that have a renderType
+            // Saving in this case only works when a programStage.id and dataElement.id are provided
+            let sortOrder = programStageDataElements.length;
+            const programStageDataElementsToAdd = map((id) => {
+                sortOrder += 1;
+                const { optionSet, valueType } = state.availableDataElements.find(dataElement => dataElement.id === id);
+                return {
                     id: generateUid(),
                     dataElement: {
-                        ...state.availableDataElements.find(dataElement => dataElement.id === id),
+                        id,
+                        optionSet,
+                        valueType,
                     },
-                }),
-                dataElementIdsToAdd
+                    programStage: {
+                        id: programStageToEdit.id,
+                    },
+                    sortOrder,
+                };
+            }, dataElementIdsToAdd,
             );
 
             programStageToEdit.programStageDataElements = programStageDataElements.concat(
-                programStageDataElementsToAdd
+                programStageDataElementsToAdd,
             );
             const programStages = getOr([], 'programStages', store.getState());
             store.setState({

--- a/src/EditModel/event-program/eventProgramStore.js
+++ b/src/EditModel/event-program/eventProgramStore.js
@@ -127,7 +127,6 @@ export const getMetaDataToSend = (state) => {
         payload.dataEntryForms = payload.dataEntryForms ?
             payload.dataEntryForms.concat(programStageDataEntryForms) : programStageDataEntryForms;
     }
-    console.log('payload', payload);
     return payload;
 };
 

--- a/src/EditModel/event-program/eventProgramStore.js
+++ b/src/EditModel/event-program/eventProgramStore.js
@@ -66,27 +66,13 @@ export const isStoreStateDirty = compose(
     value => func => func(value)
 );
 
-const sanitizeProgramTrackedEntityAttributes = (program) => {
-    if (program.programTrackedEntityAttributes) {
-        program.programTrackedEntityAttributes.forEach(programAttribute => {
-            // Make sure the trackedEntityAttribute only has the ID property, nothing else
-            programAttribute.trackedEntityAttribute = {
-                id: programAttribute.trackedEntityAttribute.id,
-            }
-        })
-    }
-    return program;
-}
-
-
 // getMetaDataToSend :: StoreState -> SaveState
 export const getMetaDataToSend = (state) => {
     const payload = {};
 
     if (isProgramDirty(state)) {
         payload.programs = [programSelector(state)]
-            .map(modelToJson)
-            .map(sanitizeProgramTrackedEntityAttributes);
+            .map(modelToJson);
 
         //For custom-form
         const programDataEntryForm = state.program.dataEntryForm;

--- a/src/EditModel/event-program/eventProgramStore.js
+++ b/src/EditModel/event-program/eventProgramStore.js
@@ -66,13 +66,27 @@ export const isStoreStateDirty = compose(
     value => func => func(value)
 );
 
+const sanitizeProgramTrackedEntityAttributes = (program) => {
+    if (program.programTrackedEntityAttributes) {
+        program.programTrackedEntityAttributes.forEach(programAttribute => {
+            // Make sure the trackedEntityAttribute only has the ID property, nothing else
+            programAttribute.trackedEntityAttribute = {
+                id: programAttribute.trackedEntityAttribute.id,
+            }
+        })
+    }
+    return program;
+}
+
+
 // getMetaDataToSend :: StoreState -> SaveState
 export const getMetaDataToSend = (state) => {
     const payload = {};
 
     if (isProgramDirty(state)) {
         payload.programs = [programSelector(state)]
-            .map(modelToJson);
+            .map(modelToJson)
+            .map(sanitizeProgramTrackedEntityAttributes);
 
         //For custom-form
         const programDataEntryForm = state.program.dataEntryForm;
@@ -127,7 +141,7 @@ export const getMetaDataToSend = (state) => {
         payload.dataEntryForms = payload.dataEntryForms ?
             payload.dataEntryForms.concat(programStageDataEntryForms) : programStageDataEntryForms;
     }
-
+    console.log('payload', payload);
     return payload;
 };
 

--- a/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/epics.js
+++ b/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/epics.js
@@ -15,26 +15,30 @@ const addAttributeToProgram = store => action$ => action$
     .ofType(PROGRAM_ATTRIBUTES_ADD)
     .map((action) => {
         const state = store.getState();
-
         const program = getOr([], 'program', state);
         const programAttributes = getOr([], 'programTrackedEntityAttributes', program);
         const attributesIdsToAdd = getOr([], 'payload.attributes', action);
+        
+        // TODO: Simplify this once JIRA issue DHIS2-4207 is done
+        // Currently simple saving failed for programAttributes that have a renderType
+        // Saving in this case only works when a program.id and trackedEntityAttribute.id are provided
         let sortOrder = programAttributes.length;
-        const attributesToAdd = map(id => {
-            sortOrder++;
+        const attributesToAdd = map((id) => {
+            sortOrder += 1;
             const { optionSet, valueType } = state.availableAttributes.find(attribute => attribute.id === id);
             return {
                 id: generateUid(),
                 trackedEntityAttribute: {
                     id,
                 },
+                program: {
+                    id: program.id,
+                },
                 optionSet,
                 valueType,
                 sortOrder,
             };
         }, attributesIdsToAdd);
-        console.log('HIERZO', programAttributes, attributesToAdd);
-
         program.programTrackedEntityAttributes = programAttributes.concat(attributesToAdd);
         store.setState({
             ...store.getState(),

--- a/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/epics.js
+++ b/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/epics.js
@@ -19,12 +19,21 @@ const addAttributeToProgram = store => action$ => action$
         const program = getOr([], 'program', state);
         const programAttributes = getOr([], 'programTrackedEntityAttributes', program);
         const attributesIdsToAdd = getOr([], 'payload.attributes', action);
-        const attributesToAdd = map(id => ({
-            id: generateUid(),
-            trackedEntityAttribute: {
-                id,
-            },
-        }), attributesIdsToAdd);
+        let sortOrder = programAttributes.length;
+        const attributesToAdd = map(id => {
+            sortOrder++;
+            const { optionSet, valueType } = state.availableAttributes.find(attribute => attribute.id === id);
+            return {
+                id: generateUid(),
+                trackedEntityAttribute: {
+                    id,
+                },
+                optionSet,
+                valueType,
+                sortOrder,
+            };
+        }, attributesIdsToAdd);
+        console.log('HIERZO', programAttributes, attributesToAdd);
 
         program.programTrackedEntityAttributes = programAttributes.concat(attributesToAdd);
         store.setState({


### PR DESCRIPTION
This PR does not only fix the problem described in the JIRA issue, but also another issue which was much worse. 

The initial issue was like this:
- To determine the available renderTypes for a dataElement/programAttribute we need access to `valueType` and `optionSet`
- For dataElements/attributes that were already attached to a programStageSection/Program, these properties were being prepared when the sore was being initialized
- But when adding new dataElements/attributes, they were not.
So this PR contains a fix for adding `valueType` and `optionSet` properties when a dataElement/attribute is added.

The second issue was that once you add a renderType to an attribute or a dataElement, they weren't saved correctly. However, by adding references to parent objects and a sortOrder explicitly this is fixed. This is of course a workaround which can be removed once JIRA issue [DHIS2-4207](https://jira.dhis2.org/browse/DHIS2-4207) is done, which is scheduled for v2.31.
So in this PR there is a fix that adds references to parent object (`programStage `, `trackedEntityAttribute`, `program`) and a `sortOrder`.

By fixing the initial issue I broke a test, which I fixed as well.