### PR TITLE
Adds the no-changes-made message for non dirty forms

### DIFF
--- a/src/EditModel/EditModel.component.js
+++ b/src/EditModel/EditModel.component.js
@@ -1,13 +1,7 @@
 import React from 'react';
 import Paper from 'material-ui/Paper/Paper';
 import EditModelForm from './EditModelForm.component';
-import { goToRoute, goToAndScrollUp } from '../router-utils';
-
-function onSaveError(errorMessage, props) {
-    if (errorMessage === 'No changes to be saved') {
-        goToAndScrollUp(`/list/${props.groupName}/${props.modelType}`);
-    }
-}
+import { goToAndScrollUp } from '../router-utils';
 
 export default function EditModel(props) {
     return (
@@ -16,7 +10,6 @@ export default function EditModel(props) {
                 {...props}
                 onCancel={() => goToAndScrollUp(`/list/${props.groupName}/${props.modelType}`)}
                 onSaveSuccess={() => goToAndScrollUp(`/list/${props.groupName}/${props.modelType}`)}
-                onSaveError={errorMessage => onSaveError(errorMessage, props)}
             />
         </Paper>
     );

--- a/src/EditModel/EditModelForm.component.js
+++ b/src/EditModel/EditModelForm.component.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import log from 'loglevel';
 import { Observable } from 'rxjs';
-import { get } from 'lodash/fp';
 
 import { getInstance } from 'd2/lib/d2';
-import { isString } from 'd2-utilizr';
 
 import CircularProgress from 'd2-ui/lib/circular-progress/CircularProgress';
 import Translate from 'd2-ui/lib/i18n/Translate.mixin';
@@ -147,6 +145,91 @@ export default React.createClass({
         this.subscription && this.subscription.unsubscribe();
     },
 
+
+    /*
+     *  Sets the style of the fields that are not part of the active steps to 'none'
+     *  so that they are "hidden". For this to work, the components needs to have
+     *  an outer div that receives the props.style.
+     */
+    setActiveStep(step) {
+        this.setState({
+            activeStep: step,
+            fieldConfigs: getStepFields(
+                step,
+                this.state.fieldConfigs,
+                this.props.modelType,
+            ),
+        });
+    },
+
+    setFormRef(form) {
+        this.formRef = form;
+    },
+
+    _onUpdateField(fieldName, value) {
+        const fieldConfig = this.state.fieldConfigs.find(fieldConfig => fieldConfig.name === fieldName);
+        if (fieldConfig && fieldConfig.beforeUpdateConverter) {
+            return objectActions.update({
+                fieldName,
+                value: fieldConfig.beforeUpdateConverter(value),
+            });
+        }
+        return objectActions.update({ fieldName, value });
+    },
+
+    _onUpdateFormStatus(formState) {
+        this.setState({
+            formState,
+        });
+    },
+
+    saveSuccess(message) {
+        snackActions.show({ message, translate: true });
+        this.props.onSaveSuccess(this.state.modelToEdit);
+    },
+
+    saveFail(error) {
+        // TODO: d2 queries require a JSON body on 200 OK, an empty body is not valid JSON
+        if (error.httpStatusCode === 200) {
+            log.warn('Save errored due to empty 200 OK body');
+
+            snackActions.show({ message: 'success', action: 'ok', translate: true });
+
+            this.props.onSaveSuccess(this.state.modelToEdit);
+        } else {
+            const firstErrorMessage = extractFirstErrorMessageFromServer(error);
+            snackActions.show({ message: firstErrorMessage, action: 'ok' });
+            log.error(error);
+        }
+    },
+
+    _saveAction(event) {
+        event.preventDefault();
+
+        const invalidFieldMessage = getFirstInvalidFieldMessage(this.state.fieldConfigs, this.formRef);
+        if (invalidFieldMessage) {
+            snackActions.show({
+                message: invalidFieldMessage,
+                action: 'ok',
+            });
+            return;
+        }
+        // Set state to saving so forms actions are being prevented
+        this.setState({ isSaving: true });
+        objectActions.saveObject({ id: this.props.modelId, modelType: this.props.modelType })
+            .subscribe(
+                this.saveSuccess,
+                this.saveFail,
+                this.setState({ isSaving: false }),
+            );
+    },
+
+    _closeAction(event) {
+        event.preventDefault();
+
+        this.props.onCancel();
+    },
+
     renderSharingNotification() {
         const formPaperStyle = {
             width: '100%',
@@ -213,93 +296,5 @@ export default React.createClass({
             return (<div>Loading data....</div>);
         }
         return this.renderForm();
-    },
-
-    /*
-     *  Sets the style of the fields that are not part of the active steps to 'none'
-     *  so that they are "hidden". For this to work, the components needs to have
-     *  an outer div that receives the props.style.
-     */
-    setActiveStep(step) {
-        this.setState({
-            activeStep: step,
-            fieldConfigs: getStepFields(
-                step,
-                this.state.fieldConfigs,
-                this.props.modelType,
-            ),
-        });
-    },
-
-    setFormRef(form) {
-        this.formRef = form;
-    },
-
-    _onUpdateField(fieldName, value) {
-        const fieldConfig = this.state.fieldConfigs.find(fieldConfig => fieldConfig.name === fieldName);
-        if (fieldConfig && fieldConfig.beforeUpdateConverter) {
-            return objectActions.update({
-                fieldName,
-                value: fieldConfig.beforeUpdateConverter(value),
-            });
-        }
-        return objectActions.update({ fieldName, value });
-    },
-
-    _onUpdateFormStatus(formState) {
-        this.setState({
-            formState,
-        });
-    },
-
-    _saveAction(event) {
-        event.preventDefault();
-
-        const invalidFieldMessage = getFirstInvalidFieldMessage(this.state.fieldConfigs, this.formRef);
-        if (invalidFieldMessage) {
-            snackActions.show({
-                message: invalidFieldMessage,
-                action: 'ok',
-            });
-            return;
-        }
-
-        // Set state to saving so forms actions are being prevented
-        this.setState({ isSaving: true });
-
-        objectActions.saveObject({ id: this.props.modelId, modelType: this.props.modelType })
-            .subscribe(
-                (message) => {
-                    this.setState({ isSaving: false });
-
-                    snackActions.show({ message, translate: true });
-
-                    this.props.onSaveSuccess(this.state.modelToEdit);
-                },
-                (error) => {
-                    // TODO: d2 queries require a JSON body on 200 OK, an empty body is not valid JSON
-                    if (error.httpStatusCode === 200) {
-                        log.warn('Save errored due to empty 200 OK body');
-
-                        snackActions.show({ message: 'success', action: 'ok', translate: true });
-
-                        return this.props.onSaveSuccess(this.state.modelToEdit);
-                    }
-
-                    const firstErrorMessage = extractFirstErrorMessageFromServer(error);
-                    snackActions.show({ message: firstErrorMessage, action: 'ok' });
-                    log.error(error);
-
-                    this.setState({ isSaving: false });
-
-                    this.props.onSaveError(error);
-                },
-            );
-    },
-
-    _closeAction(event) {
-        event.preventDefault();
-
-        this.props.onCancel();
     },
 });


### PR DESCRIPTION
Adds "no changes made" snackbar message when clicking save on an pre-existing form.

- Removed onSaveError function in EditModel. This was both contextually wrong (no changes is not an error) and was also hardcoded to an english, such that it would only work on instances with english language. This is rather handled in the objectActions.saveObject.

- Refactored saveSuccess and saveFail into two functions in EditModelForm. _saveAction.

- Linting
