### PR TITLE
Fixes incorrect UID on programAttributes in message template

### DIFF
--- a/src/config/field-overrides/validation-notification-template/VariableList.js
+++ b/src/config/field-overrides/validation-notification-template/VariableList.js
@@ -21,7 +21,12 @@ const styles = {
 
 const VariableList = ({ onItemSelected, variableTypes }, { d2 }) => {
     const renderListItem = ([type, name]) => {
-        const varName = name.id ? name.id : name;
+        const varName = name.id
+            ? type === 'A'
+                ? name.trackedEntityAttribute.id
+                : name.id
+            : name;
+
         const label = name.displayName
             ? name.displayName
             : d2.i18n.getTranslation(name);


### PR DESCRIPTION
A `programAttribute` JSON looks like this (I've stripped irrelevant properties):
```javascript
{
  name: "Child Programme First name",
  id: "l2T72XzBCLd",
  trackedEntityAttribute: {
    id: "w75KJ2mc4zz"
  }
}
```

Previously the top level `id` property was inserted into the message template, but this should have been the `trackedEntityAttribute.id`.

So now we have ended up with a nested ternary and pretty bad variable naming.... 

I decided not to fix the naming, because the `name` variable, which is actually an object containing much more info than just a name, is being used by multiple components.

The logic is for populating the message template is now like this:
- For a `variableType` we use just its value, which actually is a name/string
- For a `dataElement` we use the `id` property
- For a `programAttribute` we use the `trackedEntityAttribute.id` property
This is a bit messy and should be fixed by normalizing the data structure in the state tree. I also didn't touch this part because this could also touch quite a few files.

Perhaps we should visit this code in the future to normalise the data structures and fix the variable naming. For now (keep in mind this is going to be used in a demo by the end of the week) I propose to just keep the current fix.