### PR TITLE
DHIS2-4369 - Fix psde assign with domainType!=TRACKER

### DIFF
--- a/src/EditModel/event-program/assign-data-elements/AssignDataElements.js
+++ b/src/EditModel/event-program/assign-data-elements/AssignDataElements.js
@@ -240,17 +240,14 @@ function AssignDataElements(props, { d2 }) {
     //This is due to a database inconsistency. This fix makes it possible to show and be able to remove these
     //elements from the UI
     const otherElems = props.model.programStageDataElements
-    .filter(v => {
-        const { dataElement } = v;
-        return dataElement.domainType && dataElement.domainType !== "TRACKER";
-    })
-    .map(v => {
-        const dataElement = v.dataElement;
-        return {
+        .filter(({ dataElement }) => (
+            dataElement.domainType !== "TRACKER"
+        ))
+        .map(({ dataElement }) => ({
             id: dataElement.id,
             text: dataElement.displayName,
             value: dataElement.id,
-        }});
+        }));
 
     itemStore.setState(
         props.trackerDataElements.map(dataElement => ({

--- a/src/EditModel/event-program/assign-data-elements/AssignDataElements.js
+++ b/src/EditModel/event-program/assign-data-elements/AssignDataElements.js
@@ -199,15 +199,33 @@ const ProgramStageDataElement = pure(
     },
 );
 
-function addRenderingOptions(renderingOptions) {
-    return (psde) => {
-        const { dataElement, ...other } = psde;
+function addDisplayProperties(dataElements, renderingOptions) {
+    return ({ dataElement, ...other }) => {
+        const deDisplayProps = dataElements.find(
+            ({ id }) => id === dataElement.id,
+        );
+        
         const renderTypeOptions = getRenderTypeOptions(dataElement, DATA_ELEMENT_CLAZZ, renderingOptions);
+        if(!deDisplayProps) {
+            console.warn("Could not find tracker-element with id", dataElement.id);
+            //fallback to info that is already contained, and add renderType
+            return {
+                ...other,
+                dataElement: {
+                    ...dataElement,
+                    renderTypeOptions,
+                },
+            };
+        }
+        const { displayName, valueType, optionSet } = deDisplayProps;
 
         return {
             ...other,
             dataElement: {
                 ...dataElement,
+                displayName,
+                valueType,
+                optionSet,
                 renderTypeOptions,
             },
         };
@@ -245,9 +263,9 @@ function AssignDataElements(props, { d2 }) {
     assignedItemStore.setState(
         props.model.programStageDataElements.map(v => v.dataElement.id)
     );
+
     const tableRows = props.model.programStageDataElements
-        .map(
-            addRenderingOptions(props.renderingOptions))
+        .map(addDisplayProperties(props.trackerDataElements, props.renderingOptions))
         .map((programStageDataElement, index) => {
             return (
                 <ProgramStageDataElement

--- a/src/EditModel/event-program/epics.js
+++ b/src/EditModel/event-program/epics.js
@@ -157,7 +157,7 @@ function loadEventProgramMetadataByProgramId(programPayload) {
                         'metadata',
                         '?fields=:owner,displayName',
                         `&programs:filter=id:eq:${programId}`,
-                        `&programs:fields=${programFields},programStages[:owner,user[id,name],displayName,programStageDataElements[:owner,renderType,dataElement[id,displayName,valueType,optionSet]],notificationTemplates[:owner,displayName],dataEntryForm[:owner],programStageSections[:owner,displayName,dataElements[id,displayName]]]`,
+                        `&programs:fields=${programFields},programStages[:owner,user[id,name],displayName,programStageDataElements[:owner,renderType,dataElement[id,displayName,valueType,optionSet,domainType]],notificationTemplates[:owner,displayName],dataEntryForm[:owner],programStageSections[:owner,displayName,dataElements[id,displayName]]]`,
                         '&dataElements:fields=id,displayName,valueType,optionSet',
                         '&dataElements:filter=domainType:eq:TRACKER',
                         '&trackedEntityAttributes:fields=id,displayName,valueType,optionSet,unique',

--- a/src/EditModel/event-program/epics.js
+++ b/src/EditModel/event-program/epics.js
@@ -303,7 +303,8 @@ async function loadAdditionalTrackerMetadata(loadedMetadata) {
  * Checks the program for elements that have programStageDataElements with
  * domainType=AGGREGATE, and gives the user a notification and the ability
  * to remove these automatically.
- * This should be done server side, ho
+ * There should be a restriction server side, but this is helpful for 
+ * already affected instances.
  * @param {*} state the state of the eventProgram store
  */
 function aggregatePSDENotification(state) {

--- a/src/Snackbar/SnackbarContainer.component.js
+++ b/src/Snackbar/SnackbarContainer.component.js
@@ -44,14 +44,16 @@ class SnackBarContainer extends Component {
         if (!this.state.snack) {
             return null;
         }
-
+        //Span wrapper for styling, to work with multiline messages
+        const actionLabel = <span style={{position: 'relative', top: '-3px'}}>{this.state.snack.action}</span>
         return (
             <Snackbar
-                style={{ maxWidth: 'auto', zIndex: 5 }}
-                bodyStyle={{ maxWidth: 'auto' }}
+                style={{ maxWidth: 'auto', height: 'auto', zIndex: 5 }}
+                bodyStyle={{ maxWidth: 'auto', height:'auto', 'lineHeight': '24px', minHeight: '48px', padding: '10px 24px'}}
+                contentStyle={{ display: 'flex', alignItems: 'center', height: '100%'}}
                 ref="snackbar"
                 message={this.state.snack.message}
-                action={this.state.snack.action}
+                action={actionLabel}
                 autoHideDuration={0}
                 open={this.state.show}
                 onActionTouchTap={this.state.snack.onActionTouchTap}


### PR DESCRIPTION
Some program stages seem to have assigned programStageDataElements where the dataElement have domainType=AGGREGATE. This should most likely not be possible, however it crashed the app when assigning dataElements to a programStage.

I'm now checking for this before populating the store, and adding elements that are assigned to the current stage into the store - so it's possible to remove the elements.
It's still won't show up in the left side of the multi-select.

Also added a title on the name column, so titles for longer data element names may be shown on hover.
