### PR TITLE
Remove partially failing workaround for API bug that has been solved

### DIFF
--- a/src/EditModel/event-program/assign-data-elements/AssignDataElements.js
+++ b/src/EditModel/event-program/assign-data-elements/AssignDataElements.js
@@ -235,32 +235,26 @@ function addDisplayProperties(dataElements, renderingOptions) {
 function AssignDataElements(props, { d2 }) {
     const itemStore = Store.create();
     const assignedItemStore = Store.create();
-    const dataElementIds = new Set();
-
-    const dataElements = props.trackerDataElements.map(dataElement => {
-        dataElementIds.add(dataElement.id);
-        return {
-            id: dataElement.id,
-            text: dataElement.displayName,
-            value: dataElement.id,
-        }
-    })
 
     //Fix for DHIS2-4369 where some program stages may contain other dataelements than TRACKER
     //This is due to a database inconsistency. This fix makes it possible to show and be able to remove these
     //elements from the UI
     const otherElems = props.model.programStageDataElements
         .filter(({ dataElement }) => (
-            dataElement.domainType !== "TRACKER" && !dataElementIds.has(dataElement.id)
+            dataElement.domainType !== "TRACKER"
         ))
         .map(({ dataElement }) => ({
             id: dataElement.id,
             text: dataElement.displayName,
             value: dataElement.id,
-        }));   
+        }));
 
     itemStore.setState(
-        dataElements.concat(otherElems)
+        props.trackerDataElements.map(dataElement => ({
+            id: dataElement.id,
+            text: dataElement.displayName,
+            value: dataElement.id,
+        })).concat(otherElems)
     );
 
     assignedItemStore.setState(

--- a/src/EditModel/event-program/assign-data-elements/AssignDataElements.js
+++ b/src/EditModel/event-program/assign-data-elements/AssignDataElements.js
@@ -235,26 +235,32 @@ function addDisplayProperties(dataElements, renderingOptions) {
 function AssignDataElements(props, { d2 }) {
     const itemStore = Store.create();
     const assignedItemStore = Store.create();
+    const dataElementIds = new Set();
+
+    const dataElements = props.trackerDataElements.map(dataElement => {
+        dataElementIds.add(dataElement.id);
+        return {
+            id: dataElement.id,
+            text: dataElement.displayName,
+            value: dataElement.id,
+        }
+    })
 
     //Fix for DHIS2-4369 where some program stages may contain other dataelements than TRACKER
     //This is due to a database inconsistency. This fix makes it possible to show and be able to remove these
     //elements from the UI
     const otherElems = props.model.programStageDataElements
         .filter(({ dataElement }) => (
-            dataElement.domainType !== "TRACKER"
+            dataElement.domainType !== "TRACKER" && !dataElementIds.has(dataElement.id)
         ))
         .map(({ dataElement }) => ({
             id: dataElement.id,
             text: dataElement.displayName,
             value: dataElement.id,
-        }));
+        }));   
 
     itemStore.setState(
-        props.trackerDataElements.map(dataElement => ({
-            id: dataElement.id,
-            text: dataElement.displayName,
-            value: dataElement.id,
-        })).concat(otherElems)
+        dataElements.concat(otherElems)
     );
 
     assignedItemStore.setState(

--- a/src/config/field-overrides/data-set/DataSetElementField.component.js
+++ b/src/config/field-overrides/data-set/DataSetElementField.component.js
@@ -64,9 +64,7 @@ class DataSetElementField extends Component {
             assignedItemStore: Store.create(),
             filterText: '',
         };
-
-        this.updateCategoryCombosForDataSetElements();
-
+        
         // TODO: Should update this with the assigned category combo name
         this.state.itemStore.setState(
             props.dataElements
@@ -110,19 +108,6 @@ class DataSetElementField extends Component {
         });
     }
 
-    updateCategoryCombosForDataSetElements() {
-        // Give all the dataSetElements that do not have a category combo assign the dataElement's category combo.
-        // This is required due to the API giving dataSetElements that do not provide a categoryCombo the `default` categoryCombo.
-        Array.from(this.props.dataSet.dataSetElements || [])
-            .forEach((dataSetElement) => {
-                const isDataSetElementDoesNotHaveCategoryCombo = dataSetElement.dataElement && dataSetElement.dataElement.categoryCombo && !dataSetElement.categoryCombo;
-
-                if (isDataSetElementDoesNotHaveCategoryCombo) {
-                    dataSetElement.categoryCombo = dataSetElement.dataElement.categoryCombo;
-                }
-            });
-    }
-
     _assignItems = (items) => {
         const updateGroupEditorState = () => {
             const uniqueItems = new Set(this.state.assignedItemStore.getState().concat(items));
@@ -130,7 +115,6 @@ class DataSetElementField extends Component {
             this.state.assignedItemStore.setState(Array.from(uniqueItems));
 
             this.updateForm(Array.from(uniqueItems));
-            this.updateCategoryCombosForDataSetElements();
         };
 
         const generateUids = numberofUids => range(0, numberofUids, 1).map(() => generateUid());


### PR DESCRIPTION
Some context on this bug:
1. The initial problem, as reported, was that `dataSetElements` would be assigned a `categoryCombo`, even even no override was selected in the _Override the data element category combination_ dialog.
2. Upon inspection, this was done intentionally to mitigate an API bug which was present some two years ago, see the comment in the removed method `updateCategoryCombosForDataSetElements `.
3. By now the API bug has been solved, so if no override is applied, no `categoryCombo` should be assigned to a `dataSetElement`.

So simply removing the old workaround fixes the problem.

To review if the behaviour is now correct:
1. Go to _Data sets_ and edit one, I suggest using _TB/HIV (VCCT) monthly summary_ because it doesn't have too many `dataSetElements` so is easy to inspect.
2. Click the wrench icon next to _Data elements_ and select one or more overrides in the dialog. Make sure you leave at least one without an override.
3. Close the dialog, make sure your network tab in DevTools is open and cleared, and click save.
4. Inspect the `dataSetElements` property in the payload of the POST to the `metadata` endpoint. Here you should see that:
a. `dataSetElements` with an override should have a `categoryCombos` property
b. `dataSetElements` without and override should not have this property.