### PR TITLE
Prevent duplicate dataElements to be added to itemStore

### DIFF
--- a/src/EditModel/event-program/assign-data-elements/AssignDataElements.js
+++ b/src/EditModel/event-program/assign-data-elements/AssignDataElements.js
@@ -235,26 +235,32 @@ function addDisplayProperties(dataElements, renderingOptions) {
 function AssignDataElements(props, { d2 }) {
     const itemStore = Store.create();
     const assignedItemStore = Store.create();
+    const dataElementIds = new Set();
+
+    const dataElements = props.trackerDataElements.map(dataElement => {
+        dataElementIds.add(dataElement.id);
+        return {
+            id: dataElement.id,
+            text: dataElement.displayName,
+            value: dataElement.id,
+        }
+    })
 
     //Fix for DHIS2-4369 where some program stages may contain other dataelements than TRACKER
     //This is due to a database inconsistency. This fix makes it possible to show and be able to remove these
     //elements from the UI
     const otherElems = props.model.programStageDataElements
         .filter(({ dataElement }) => (
-            dataElement.domainType !== "TRACKER"
+            dataElement.domainType !== "TRACKER" && !dataElementIds.has(dataElement.id)
         ))
         .map(({ dataElement }) => ({
             id: dataElement.id,
             text: dataElement.displayName,
             value: dataElement.id,
-        }));
+        }));   
 
     itemStore.setState(
-        props.trackerDataElements.map(dataElement => ({
-            id: dataElement.id,
-            text: dataElement.displayName,
-            value: dataElement.id,
-        })).concat(otherElems)
+        dataElements.concat(otherElems)
     );
 
     assignedItemStore.setState(

--- a/src/EditModel/event-program/assign-data-elements/AssignDataElements.js
+++ b/src/EditModel/event-program/assign-data-elements/AssignDataElements.js
@@ -246,9 +246,11 @@ function AssignDataElements(props, { d2 }) {
         }
     })
 
-    //Fix for DHIS2-4369 where some program stages may contain other dataelements than TRACKER
-    //This is due to a database inconsistency. This fix makes it possible to show and be able to remove these
-    //elements from the UI
+    /* Fix for DHIS2-4369 where some program stages may contain other dataelements than TRACKER
+    This is due to a database inconsistency. This fix makes it possible to show and be able to remove these
+    elements from the UI.
+    itemStore needs to be a superset of all assigned items, so we add the items that are assigned,
+    but may not be in prop.trackerDataElements  */
     const otherElems = props.model.programStageDataElements
         .filter(({ dataElement }) => (
             dataElement.domainType !== "TRACKER" && !dataElementIds.has(dataElement.id)


### PR DESCRIPTION
The code below works, but if we could work out why these duplicates were being added that would be even better.