### PR TITLE
DHIS2-4435-orgunit-pager

### DIFF
--- a/src/List/organisation-unit-list/OrganisationUnitList.component.js
+++ b/src/List/organisation-unit-list/OrganisationUnitList.component.js
@@ -9,17 +9,10 @@ import ModelCollection from 'd2/lib/model/ModelCollection';
 //create a monkey-patch to handle paging with prepended-orgunit
 const createPagerForOrgunit = (pager, selectedOrganisationUnit, d2) => {
     const monkeyPage = async pageNr => {
-        if (pageNr < 1) {
-            throw new Error('PageNr can not be less than 1');
-        }
-        if (pageNr > this.pageCount) {
-            throw new Error(`PageNr can not be larger than the total page count of ${this.pageCount}`);
-        }
-        const orgList = await pager.pagingHandler.list(Object.assign({}, pager.query, { page: pageNr }));
-        let orgListPager = orgList.pager;
+        const orgList = await pager.goToPage(pageNr);
         const orgListArr = orgList.toArray();
         orgListArr.unshift(selectedOrganisationUnit);
-        let prependedOrgUnitList = ModelCollection.create(d2.models.organisationUnit, orgListArr, orgListPager);
+        let prependedOrgUnitList = ModelCollection.create(d2.models.organisationUnit, orgListArr, orgList.pager);
         
         prependedOrgUnitList.pager.goToPage = monkeyPage;
         return prependedOrgUnitList;

--- a/src/List/organisation-unit-list/OrganisationUnitList.component.js
+++ b/src/List/organisation-unit-list/OrganisationUnitList.component.js
@@ -1,24 +1,38 @@
-import React from 'react';
-import List from '../List.component';
-import appState from '../../App/appStateStore';
 import { getInstance } from 'd2/lib/d2';
-import listActions, { fieldFilteringForQuery } from '../list.actions';
-import log from 'loglevel';
 import ModelCollection from 'd2/lib/model/ModelCollection';
+import log from 'loglevel';
+import React from 'react';
+import appState from '../../App/appStateStore';
+import listActions, { fieldFilteringForQuery } from '../list.actions';
+import List from '../List.component';
 
-//create a monkey-patch to handle paging with prepended-orgunit
-const createPagerForOrgunit = (pager, selectedOrganisationUnit, d2) => {
+/**
+ * Create a monkey-patch to handle paging with prepended-orgunit
+ * @param pager the orginial Pager-instance of the list to monkey-patch
+ * @return the monkey-patched goToPage function that will add the selectedOrganisation unit
+ * to the result of the paged-list
+ */
+const createGoToPagerForOrgunit = (pager, selectedOrganisationUnit, d2) => {
     const monkeyPage = async pageNr => {
         const orgList = await pager.goToPage(pageNr);
-        const orgListArr = orgList.toArray();
-        orgListArr.unshift(selectedOrganisationUnit);
-        let prependedOrgUnitList = ModelCollection.create(d2.models.organisationUnit, orgListArr, orgList.pager);
-        
-        prependedOrgUnitList.pager.goToPage = monkeyPage;
-        return prependedOrgUnitList;
+        return createPrependedOrgUnitList(selectedOrganisationUnit, orgList, d2);
     }
     return monkeyPage;
 }
+
+/**
+ * Returns a ModelCollection with given organisationUnitList prepended by
+ * selectedOrganisationUnit.
+ */
+const createPrependedOrgUnitList = (selectedOrganisationUnit, organisationUnitList, d2 ) => {
+    let filteredOrgUnits = organisationUnitList.toArray();
+    filteredOrgUnits.unshift(selectedOrganisationUnit);
+    let prependedOrgUnitList = ModelCollection.create(d2.models.organisationUnit, filteredOrgUnits,organisationUnitList.pager);
+    prependedOrgUnitList.pager.goToPage = createGoToPagerForOrgunit(organisationUnitList.pager, selectedOrganisationUnit, d2)
+
+    return prependedOrgUnitList;
+}
+
 export default class OrganisationUnitList extends React.Component {
     componentDidMount() {
         this.subscription = appState
@@ -51,11 +65,7 @@ export default class OrganisationUnitList extends React.Component {
                     // DHIS2-2160 Add the selected node to the list to
                     // avoid having to select the parent node to edit
                     // the selected node...
-                    let filteredOrgUnits = organisationUnitList.toArray();
-                 
-                    filteredOrgUnits.unshift(selectedOrganisationUnit);
-                    let prependedOrgUnitList = ModelCollection.create(d2.models.organisationUnit, filteredOrgUnits,organisationUnitList.pager);
-                    prependedOrgUnitList.pager.goToPage = createPagerForOrgunit(organisationUnitList.pager, selectedOrganisationUnit, d2)
+                    let prependedOrgUnitList = createPrependedOrgUnitList(selectedOrganisationUnit, organisationUnitList, d2);
                     listActions.setListSource(prependedOrgUnitList);
                 },
                 error => log.error(error)

--- a/src/List/organisation-unit-list/OrganisationUnitList.component.js
+++ b/src/List/organisation-unit-list/OrganisationUnitList.component.js
@@ -22,7 +22,6 @@ const createPagerForOrgunit = (pager, selectedOrganisationUnit, d2) => {
         let prependedOrgUnitList = ModelCollection.create(d2.models.organisationUnit, orgListArr, orgListPager);
         
         prependedOrgUnitList.pager.goToPage = monkeyPage;
-        console.log(prependedOrgUnitList)
         return prependedOrgUnitList;
     }
     return monkeyPage;
@@ -60,7 +59,6 @@ export default class OrganisationUnitList extends React.Component {
                     // avoid having to select the parent node to edit
                     // the selected node...
                     let filteredOrgUnits = organisationUnitList.toArray();
-                    console.log(organisationUnitList)
                  
                     filteredOrgUnits.unshift(selectedOrganisationUnit);
                     let prependedOrgUnitList = ModelCollection.create(d2.models.organisationUnit, filteredOrgUnits,organisationUnitList.pager);


### PR DESCRIPTION
This is a horrible hack...
But it works.

goToPage is called on the pager-object, and returns a List, with the new values for the page. I call this, but then prepend the selected value, like when loading the list for the first time. 
To do this we need to monkey-patch the goToPage, with the logic for prepending the selected unit.