### PR TITLE
fix/DHIS2-4682-optionset-unique-validation

### DIFF
--- a/src/EditModel/option-set/OptionDialogForOptions/OptionDialogForOptions.component.js
+++ b/src/EditModel/option-set/OptionDialogForOptions/OptionDialogForOptions.component.js
@@ -44,8 +44,9 @@ const addAttributeStatusToFieldConfig = (fieldConfig, model) => {
     }
 };
 
-async function setupFieldConfigs([fieldConfigs, modelToEdit, optionDialogState]) {
+async function setupFieldConfigs([modelToEdit, optionDialogState]) {
     const d2 = await getInstance();
+    const fieldConfigs = await createFieldConfigForModelTypes('option');
     const isAdd = !optionDialogState.model.id;
     const model = optionDialogState.model;
 
@@ -61,10 +62,8 @@ async function setupFieldConfigs([fieldConfigs, modelToEdit, optionDialogState])
 
 const optionForm$ = Observable
     .combineLatest(
-        Observable.fromPromise(createFieldConfigForModelTypes('option')),
-        modelToEditStore,
-        optionDialogStore,
-    )
+        modelToEditStore, //This is the optionSet model. optionDialogStore.model contains option model
+        optionDialogStore)
     .flatMap(setupFieldConfigs);
 
 const optionFormData$ = Observable.combineLatest(
@@ -78,14 +77,13 @@ const optionFormData$ = Observable.combineLatest(
     }))
     .flatMap(async ({ fieldConfigs, model, isAdd, ...other }) => {
         const d2 = await getInstance();
-
-        return Promise.resolve({
+        return {
             fieldConfigs,
             model,
             isAdd,
             title: d2.i18n.getTranslation(isAdd ? 'option_add' : 'option_edit'),
             ...other,
-        });
+        };
     })
     .filter(({ fieldConfigs }) => fieldConfigs.length);
 


### PR DESCRIPTION
Sometimes when you deleted an option within an optionSet, and tried to add or edit a new one with the same new, you would get an error saying that it needs to be unique.

It was difficult to reproduce this bug, as it happened randomly when editing and adding options as well.
I believe the reason was that the promise in the fromPromise-call within combineLatest would return the same object (as fromPromise completes the stream). I moved the call to the setupFieldConfigs as that is already an async function.

This should probably be refactored more, as some of the validation code is just duplicates of already existing code in formHelpers.js

