### PR TITLE
Get fresh attributes before rendering the option-set editor

### DIFF
--- a/src/EditModel/EditOptionSet.component.js
+++ b/src/EditModel/EditOptionSet.component.js
@@ -12,6 +12,7 @@ import EditModelForm from './EditModelForm.component';
 import OptionManagement from './option-set/OptionManagement.component';
 import FormHeading from './FormHeading';
 import { goToRoute } from '../router-utils';
+import LoadingMask from '../loading-mask/LoadingMask.component';
 
 function onSaveError(errorMessage, props) {
     if (errorMessage === 'No changes to be saved') {
@@ -25,7 +26,45 @@ class EditOptionSet extends Component {
 
         this.state = {
             tabsValue: props.params.activeView || '',
+            loading: true,
         };
+    }
+
+    async componentDidMount() {
+        const api = this.context.d2.Api.getApi();
+
+        try {
+            const { attributes } = await api.get('attributes', { fields: ':all,optionSet[:all,options[:all]]', paging: false });
+
+            this.reloadAttributes('optionSet', attributes);
+            this.reloadAttributes('option', attributes);
+
+        } catch (error) {
+            console.error(error);
+
+        } finally {
+            this.setState({ loading: false });
+        }
+    }
+
+    reloadAttributes(modelDefinitionName, attributes) {
+            const modelDefinition = this.context.d2.models[modelDefinitionName];
+            const schemaAttributes = attributes.filter((attributeDescriptor) => {
+                return attributeDescriptor[`${modelDefinitionName}Attribute`] === true;
+            });
+
+            // clear without reassigning 
+            for (const key in modelDefinition.attributeProperties) {
+                if (modelDefinition.attributeProperties.hasOwnProperty(key)) {
+                    delete modelDefinition.attributeProperties[key];
+                }
+            }
+
+            // Attach fresh attributes
+            for (const attribute of schemaAttributes) {
+                modelDefinition.attributeProperties[attribute.name] = attribute;
+            }
+        
     }
 
     render() {
@@ -64,6 +103,10 @@ class EditOptionSet extends Component {
                 goToRoute(`/list/${params.groupName}/${params.modelType}`);
             }
         };
+
+        if (this.state.loading) {
+            return <LoadingMask />
+        }
 
         return (
             <div>


### PR DESCRIPTION
This does fix issue DHIS2-1283, but it is quite a hacky solution. Perhaps the solution itself is not bad, but I think this might have to be a method in d2 instead. So that in the maintenance app we can just write something like `await modelDefinition.reloadAttributeProperties()`

I'll explain things step by step:
1. In the `init` function of `d2` all of the d2.models are [intialized with their schemaAttributes](https://github.com/dhis2/d2/blob/v30/src/d2.js#L308-L316). These attributes will ultimately become the [`attributeProperties` for the model](https://github.com/dhis2/d2/blob/v30/src/model/ModelDefinition.js#L144)
2. So effectively `d2` is treating these `attributeProperties` as static data. But we are in the maintenance-app where anything can change, `attributes` included.
3. So what would happen, after adding some `attribute`, and then (without refreshing the page) editing an `optionSet`, was that the new attribute would not be displayed. This is because how the `createAttributeFieldConfigs` function in `formHelpers.js` constructs the fields. [It just loops though `modelDefinition.attributeProperties`](https://github.com/dhis2/maintenance-app/blob/DHIS2-1283-attribute-not-created-for-option/src/EditModel/formHelpers.js#L31-L33), which `d2` considers to be _static data_ :-(.

So, I hope the problem is clear from the explanation above.... Any type of solution will involve reloading the `attributeProperties` of a `modelDefinition`. As you can see below, I have simply done it in the `EditOptionSet` component for now. I'm not sure if this is good enough to merge, there are quite a few issues with this:
- Object mutations of a d2 modelDefinition from inside a React component: NASTY
- This fix is very isolated. You could argue that after a save to the `attributes` endpoint all relevant `modelDefinitions` `attributeProperties` should be updated. This way we prevent the same issue happening elsewhere in the app.

So, I am very open to suggestions. Let me know what you think.