### PR TITLE
DHIS2-4584-delete-program-stage

### DIFF
--- a/src/EditModel/event-program/tracker-program/epics.js
+++ b/src/EditModel/event-program/tracker-program/epics.js
@@ -198,7 +198,7 @@ const confirmDeleteProgramStage = action$ =>
             const index = getProgramStageIndexById(action.stageId)(
                 store,
             );
-            if(index < 0) return deleteProgramStageError();
+            if(index < 0) return Observable.of(deleteProgramStageError());
 
             const model = store.programStages[index];
 
@@ -206,7 +206,7 @@ const confirmDeleteProgramStage = action$ =>
             //dispatching actions inside an epic is kind of an anti-pattern
             //but this is gray-zone as its an callback that is created by the epic
             deleteProgramStageWithSnackbar(model);
-            return { type: "CONFIRM_DELETE_PROGRAM_STAGE_PENDING" };
+            return Observable.of({ type: "CONFIRM_DELETE_PROGRAM_STAGE_PENDING" });
         });
 
 const deleteProgramStage = action$ =>

--- a/src/EditModel/event-program/tracker-program/program-stages/ProgramStageList.js
+++ b/src/EditModel/event-program/tracker-program/program-stages/ProgramStageList.js
@@ -18,7 +18,7 @@ import { translationSaved, translationError } from './contextActions';
 import {
     editProgramStage,
     addProgramStage,
-    deleteProgramStage,
+    confirmDeleteProgramStage
 } from './actions';
 
 const styles = {
@@ -253,7 +253,7 @@ export default connect(null, dispatch =>
         {
             handleEditProgramStage: model => editProgramStage(model.id),
             handleNewProgramStage: () => addProgramStage(),
-            handleDeleteProgramStage: model => deleteProgramStage(model.id),
+            handleDeleteProgramStage: model => confirmDeleteProgramStage(model.id),
         },
         dispatch,
     ),

--- a/src/EditModel/event-program/tracker-program/program-stages/actions.js
+++ b/src/EditModel/event-program/tracker-program/program-stages/actions.js
@@ -1,4 +1,5 @@
 import { createActionCreator } from '../../../actions';
+import { notifyUser } from '../../../actions';
 
 export const PROGRAM_STAGE_STEP_CHANGE = 'PROGRAM_STAGE_STEP_CHANGE';
 export const PROGRAM_STAGE_STEP_NEXT = 'PROGRAM_STAGE_STEP_NEXT';
@@ -12,6 +13,7 @@ export const PROGRAM_STAGE_EDIT_RESET = 'PROGRAM_STAGE_EDIT_RESET';
 export const PROGRAM_STAGE_EDIT_CANCEL = 'PROGRAM_STAGE_EDIT_CANCEL';
 export const PROGRAM_STAGE_EDIT_SAVE = 'PROGRAM_STAGE_EDIT_SAVE';
 
+export const CONFIRM_PROGRAM_STAGE_DELETE = 'CONFIRM_PROGRAM_STAGE_DELETE';
 export const PROGRAM_STAGE_DELETE = 'PROGRAM_STAGE_DELETE';
 export const PROGRAM_STAGE_DELETE_ERROR = 'PROGRAMSTAGE_DELETE_ERROR';
 export const PROGRAM_STAGE_DELETE_SUCCESS = 'PROGRAM_STAGE_DELETE_SUCCESS';
@@ -48,5 +50,16 @@ export const cancelProgramStageEdit = () => ({
 });
 
 export const deleteProgramStage = stageId => createActionCreator(PROGRAM_STAGE_DELETE)({ stageId });
-export const deleteProgramStageSuccess = createActionCreator(PROGRAM_STAGE_DELETE_SUCCESS);
-export const deleteProgramStageError = createActionCreator(PROGRAM_STAGE_DELETE_ERROR);
+export const deleteProgramStageSuccess = () => notifyUser({
+    message: 'item_deleted_successfully',
+    translate: true,
+});
+
+export const deleteProgramStageError = (e) => {
+    const message = e && e.message;
+    return notifyUser({
+        message: message ? message : 'failed_to_save',
+        translate: !message
+    })
+}
+export const confirmDeleteProgramStage = stageId => createActionCreator(CONFIRM_PROGRAM_STAGE_DELETE)({ stageId });

--- a/src/EditModel/event-program/tracker-program/program-stages/contextActions.js
+++ b/src/EditModel/event-program/tracker-program/program-stages/contextActions.js
@@ -3,11 +3,14 @@ import { afterDeleteHook$ } from '../../../../List/ContextActions';
 import camelCaseToUnderscores from 'd2-utilizr/lib/camelCaseToUnderscores';
 import { getInstance } from 'd2/lib/d2';
 import log from 'loglevel';
-import { deleteProgramStageFromState } from '../epics';
+import { deleteProgramStage } from './actions';
+
+import store from '../../../../store';
 
 export async function deleteProgramStageWithSnackbar(model) {
     const d2 = await getInstance();
-    snackActions.show({
+
+        snackActions.show({
         message: [
             d2.i18n.getTranslation(
                 `confirm_delete_${camelCaseToUnderscores(
@@ -19,7 +22,7 @@ export async function deleteProgramStageWithSnackbar(model) {
         action: 'confirm',
 
         onActionTouchTap: () => {
-            deleteProgramStageFromState(model.id);
+            store.dispatch(deleteProgramStage(model.id));
 
             // Fire the afterDeleteHook
             afterDeleteHook$.next({


### PR DESCRIPTION
Updated delete-epic to call api DELETE when deleting program stage.

If we just deleted from the programStage-array an posted this to the server, they were not properly deleted.

A consequence of this is that you cannot delete the program stage if it hasn't already been saved. So creating a stage and then deleting it results in an error.
We could consider checking for 404 when deleting, and just remove it from the state if this is the case. This might be a bit less transparent to the user though, as the same thing would happen if someone else has deleted the program stage in the mean time... And it would be difficult to differentiate between "The program stage does not exist on the server because it has not been saved yet" and "the program stage does not exist due to some other error". 

I do not want to introduce a flag in the state to check if the stage has been saved to server or not. Will just cause bugs and annoyance. 

This is a pretty serious bug, as described in the issue. Should probably be backported to both 2.30 and 2.29...