### PR TITLE
Remove custom attributes on enrollment step in trackerprograms

### DIFF
--- a/src/EditModel/event-program/tracker-program/EnrollmentStep.js
+++ b/src/EditModel/event-program/tracker-program/EnrollmentStep.js
@@ -20,7 +20,7 @@ const connectEditForm = compose(
 );
 
 const EnrollmentDetailsForm = connectEditForm(
-    createFormFor(program$, 'program', enrollmentFields, true, 'enrollment')
+    createFormFor(program$, 'program', enrollmentFields, false, 'enrollment')
 );
 
 const EnrollmentDetails = props => (

--- a/src/EditModel/event-program/tracker-program/TrackerProgramStepperContent.js
+++ b/src/EditModel/event-program/tracker-program/TrackerProgramStepperContent.js
@@ -35,9 +35,7 @@ const stepperConfig = () => {
                 createFormFor(program$, 'program', trackerDetailsFields, true, 'trackerProgram'),
             ),
         ),
-        Enrollment: EnrollmentDetails,/*connectEditForm(
-            wrapInPaper(createFormFor(program$, 'program', enrollmentFields, true, 'enrollment')),
-        ), */
+        Enrollment: EnrollmentDetails,
         AssignAttributes,
         ProgramStage,
         EditDataEntryForm,


### PR DESCRIPTION
The custom attributes is already listed in the first step "Program details".
Confusing that is shows up in the enrollment step as well.