### PR TITLE
Use templateUid for programRule. Load templateUids on programRuleEdit

### DIFF
--- a/src/EditModel/SingleModelStore.js
+++ b/src/EditModel/SingleModelStore.js
@@ -73,12 +73,12 @@ export const requestParams = new Map([
         fields: [
             ':all',
             'programRuleActions[:all',
+            'templateUid',
             'dataElement[id,displayName]',
             'option[id,displayName]',
             'optionGroup[id,displayName]',
             'trackedEntityAttribute[id,displayName]',
             'programStage[id,displayName]',
-            'programNotificationTemplate[id,displayName]',
             'programStageSection[id,displayName]]',
         ].join(','),
     }],

--- a/src/config/field-overrides/program-rules/programRuleActionDialog.component.js
+++ b/src/config/field-overrides/program-rules/programRuleActionDialog.component.js
@@ -189,8 +189,8 @@ class ProgramRuleActionDialog extends React.Component {
                 if(ref) {
                     if(field === 'templateUid') {
                         // just use the id, instead of object reference and update
-                        // programNotificationTemplate to be used in the list (instead of fetching again... not sent to server)
-                        programRuleAction.programNotificationTemplate = { id: ref.value, displayName: ref.text };
+                        // notificationTemplate in the programRuleActionList
+                        programRuleAction.notificationTemplate = { id: ref.value, displayName: ref.text };
                     } else {
                         programRuleAction[field] = { id: ref.value, displayName: ref.text };
                     }
@@ -206,12 +206,13 @@ class ProgramRuleActionDialog extends React.Component {
             this.props.parentModel.programRuleActions.set(programRuleAction.id, programRuleAction);
             this.props.parentModel.programRuleActions.dirty = true;
             // </hack>
-
+            this.props.onUpdateRuleActionModel(programRuleAction);
             this.props.onChange({ target: { value: this.props.parentModel.programRuleActions } });
             this.props.onRequestClose();
         } else {
             const newUid = await this.d2.Api.getApi().get('/system/id');
             this.props.parentModel.programRuleActions.add(Object.assign(programRuleAction, { id: newUid.codes[0] }));
+            this.props.onUpdateRuleActionModel(programRuleAction);
             this.props.onChange({ target: { value: this.props.parentModel.programRuleActions } });
             this.props.onRequestClose();
         }

--- a/src/config/field-overrides/program-rules/programRuleActionDialog.component.js
+++ b/src/config/field-overrides/program-rules/programRuleActionDialog.component.js
@@ -179,15 +179,22 @@ class ProgramRuleActionDialog extends React.Component {
             trackedEntityAttribute: this.state.programTrackedEntityAttributes,
             programStage: this.state.programStages,
             programStageSection: this.state.programSections,
-            programNotificationTemplate: this.state.notificationTemplates,
+            templateUid: this.state.notificationTemplates,
             option: this.state.options,
             optionGroup: this.state.optionGroups,
         };
-
         Object.keys(fieldRefs).forEach((field) => {
             if (programRuleAction[field]) {
-                const ref = fieldRefs[field].filter(v => v.value === programRuleAction[field])[0];
-                programRuleAction[field] = { id: ref.value, displayName: ref.text };
+                const ref = fieldRefs[field].find(v => v.value === programRuleAction[field]);
+                if(ref) {
+                    if(field === 'templateUid') {
+                        // just use the id, instead of object reference and update
+                        // programNotificationTemplate to be used in the list (instead of fetching again... not sent to server)
+                        programRuleAction.programNotificationTemplate = { id: ref.value, displayName: ref.text };
+                    } else {
+                        programRuleAction[field] = { id: ref.value, displayName: ref.text };
+                    }
+                }
             } else {
                 programRuleAction[field] = undefined;
             }
@@ -396,12 +403,12 @@ class ProgramRuleActionDialog extends React.Component {
                 },
             },
             {
-                name: 'programNotificationTemplate',
+                name: 'templateUid',
                 component: DropDown,
                 props: {
                     labelText: this.getTranslation('program_notification_template'),
                     options: this.state && this.state.notificationTemplates || [],
-                    value: ruleActionModel.programNotificationTemplate,
+                    value: ruleActionModel.templateUid,
                     disabled: !this.state.notificationTemplates || this.state.notificationTemplates === 0,
                     fullWidth: true,
                 },

--- a/src/config/field-overrides/program-rules/programRuleActionList.component.js
+++ b/src/config/field-overrides/program-rules/programRuleActionList.component.js
@@ -36,7 +36,6 @@ class ProgramRuleActionsList extends React.Component {
                             id: notificationTemplate.id,
                             displayName: notificationTemplate.displayName,
                         }
-                        this.setState({});
                     })
                 }
             })
@@ -130,6 +129,7 @@ class ProgramRuleActionsList extends React.Component {
                     field}`;
                 break;
 
+            case 'SCHEDULEMESSAGE':
             case 'SENDMESSAGE':
                 const withDateString = action.data ? `${this.getTranslation('at_date')} "${action.data}"` : ''
                 const displayName = action.programNotificationTemplate
@@ -142,38 +142,39 @@ class ProgramRuleActionsList extends React.Component {
 
                 break;
 
-                case 'HIDEOPTION':
-                    field = [
-                        action.dataElement && `"${action.dataElement.displayName}"`,
-                        action.trackedEntityAttribute && `"${action.trackedEntityAttribute.displayName}"`,
-                    ].filter(s => s).map(s => s.trim()).join(', ');
-                    const option = action.option && action.option.displayName;
-                    field = field ? `"${option}" ${this.getTranslation('on')} ${field}` : '';
-                    actionDetails = `${this.getTranslation(programRuleActionTypes[action.programRuleActionType].label)}: ${
-                        field}`;
-                    break;
-                case 'SHOWOPTIONGROUP': {
-                    field = [
-                        action.dataElement && `"${action.dataElement.displayName}"`,
-                        action.trackedEntityAttribute && `"${action.trackedEntityAttribute.displayName}"`,
-                    ].filter(s => s).map(s => s.trim()).join(', ');
-                    const optionGrp = action.optionGroup && action.optionGroup.displayName;
-                    field = field ? `"${optionGrp}" ${this.getTranslation('on')} ${field}` : '';
-                    actionDetails = `${this.getTranslation(programRuleActionTypes[action.programRuleActionType].label)}: ${
-                        field}`;
-                    break;
-                }
+            case 'HIDEOPTION':
+                field = [
+                    action.dataElement && `"${action.dataElement.displayName}"`,
+                    action.trackedEntityAttribute && `"${action.trackedEntityAttribute.displayName}"`,
+                ].filter(s => s).map(s => s.trim()).join(', ');
+                const option = action.option && action.option.displayName;
+                field = field ? `"${option}" ${this.getTranslation('on')} ${field}` : '';
+                actionDetails = `${this.getTranslation(programRuleActionTypes[action.programRuleActionType].label)}: ${
+                    field}`;
+                break;
 
-                case 'HIDEOPTIONGROUP': {
-                    field = [
-                        action.dataElement && `"${action.dataElement.displayName}"`,
-                        action.trackedEntityAttribute && `"${action.trackedEntityAttribute.displayName}"`,
-                    ].filter(s => s).map(s => s.trim()).join(', ');
-                    const optionGrp = action.optionGroup && action.optionGroup.displayName;
-                    field = field ? `"${optionGrp}" ${this.getTranslation('on')} ${field}` : '';
-                    actionDetails = `${this.getTranslation(programRuleActionTypes[action.programRuleActionType].label)}: ${
-                        field}`;
-                    break;
+            case 'SHOWOPTIONGROUP': {
+                field = [
+                    action.dataElement && `"${action.dataElement.displayName}"`,
+                    action.trackedEntityAttribute && `"${action.trackedEntityAttribute.displayName}"`,
+                ].filter(s => s).map(s => s.trim()).join(', ');
+                const optionGrp = action.optionGroup && action.optionGroup.displayName;
+                field = field ? `"${optionGrp}" ${this.getTranslation('on')} ${field}` : '';
+                actionDetails = `${this.getTranslation(programRuleActionTypes[action.programRuleActionType].label)}: ${
+                    field}`;
+                break;
+            }
+
+            case 'HIDEOPTIONGROUP': {
+                field = [
+                    action.dataElement && `"${action.dataElement.displayName}"`,
+                    action.trackedEntityAttribute && `"${action.trackedEntityAttribute.displayName}"`,
+                ].filter(s => s).map(s => s.trim()).join(', ');
+                const optionGrp = action.optionGroup && action.optionGroup.displayName;
+                field = field ? `"${optionGrp}" ${this.getTranslation('on')} ${field}` : '';
+                actionDetails = `${this.getTranslation(programRuleActionTypes[action.programRuleActionType].label)}: ${
+                    field}`;
+                break;
                 }
 
             default:

--- a/src/config/field-overrides/program-rules/programRuleActionList.component.js
+++ b/src/config/field-overrides/program-rules/programRuleActionList.component.js
@@ -21,6 +21,27 @@ class ProgramRuleActionsList extends React.Component {
             currentRuleActionModel: {},
         };
     }
+    componentDidMount() {
+        this.loadProgramRuleActionTemplate();
+    }
+
+    loadProgramRuleActionTemplate() {
+        const programRuleActions = this.props.model[this.props.referenceProperty].toArray();
+
+        if(programRuleActions.length > -1 ) {
+            programRuleActions.forEach(action => {
+                if(action.templateUid) {
+                    this.d2.models.programNotificationTemplates.get(action.templateUid).then(notificationTemplate => {
+                        action.programNotificationTemplate = {
+                            id: notificationTemplate.id,
+                            displayName: notificationTemplate.displayName,
+                        }
+                        this.setState({});
+                    })
+                }
+            })
+        }
+    }
 
     addProgramRuleAction() {
         this.setState({

--- a/src/config/field-overrides/program-rules/programRuleActionTypes.js
+++ b/src/config/field-overrides/program-rules/programRuleActionTypes.js
@@ -124,14 +124,14 @@ const actionTypeFieldMapping = {
     },
     SENDMESSAGE: {
         label: 'send_message',
-        optional: ['programNotificationTemplate', 'data'],
+        optional: ['templateUid', 'data'],
         labelOverrides: {
             data: 'date_to_send_message'
         }
     },
     SCHEDULEMESSAGE: {
         label: 'schedule_message',
-        required: ['programNotificationTemplate', 'data'],
+        required: ['templateUid', 'data'],
         labelOverrides: {
             data: 'date_to_send_message',
         }

--- a/src/config/field-overrides/program-rules/programRuleProgramStage.js
+++ b/src/config/field-overrides/program-rules/programRuleProgramStage.js
@@ -29,7 +29,10 @@ class ProgramStageField extends React.Component {
     render() {
         const props = this.props;
         const disabled = !this.state.programId;
-        
+
+        // Do not load, to prevent loading without filter before the program is selected
+        if(disabled) return null;
+
         return (
             <DropdownAsync
                 {...props}

--- a/src/config/field-overrides/program-rules/programRuleProgramStage.js
+++ b/src/config/field-overrides/program-rules/programRuleProgramStage.js
@@ -30,7 +30,7 @@ class ProgramStageField extends React.Component {
         const props = this.props;
         const disabled = !this.state.programId;
 
-        // Do not load, to prevent loading without filter before the program is selected
+        // Do not render, to prevent loading without filter before the program is selected
         if(disabled) return null;
 
         return (


### PR DESCRIPTION
The reference from programRuleAction -> programNotificationTemplate was removed and replaced by just a string for performance reasons on the backend. 

This means we cannot use fieldFiltering to get the name of the notification in the list, so we need to get this when we load a programRule with programRuleAction that has notificationTemplates.

More complexity on the frontend, yey!