### PR TITLE
Fix/dhis2 5323 configurable columns orgunit load

### DIFF
--- a/src/List/list.actions.js
+++ b/src/List/list.actions.js
@@ -97,7 +97,7 @@ function getOrderingForSchema(modelName) {
     return 'displayName:ASC';
 }
 
-function getQueryForSchema(modelName) {
+export function getQueryForSchema(modelName) {
     return {
         fields: [
             fieldFilteringForQuery,

--- a/src/List/organisation-unit-list/OrganisationUnitList.component.js
+++ b/src/List/organisation-unit-list/OrganisationUnitList.component.js
@@ -3,7 +3,7 @@ import ModelCollection from 'd2/lib/model/ModelCollection';
 import log from 'loglevel';
 import React from 'react';
 import appState from '../../App/appStateStore';
-import listActions, { fieldFilteringForQuery } from '../list.actions';
+import listActions, { fieldFilteringForQuery, getQueryForSchema } from '../list.actions';
 import List from '../List.component';
 import listStore from '../list.store';
 
@@ -48,28 +48,31 @@ export default class OrganisationUnitList extends React.Component {
             }, reload]))
             .filter(([state]) => state.selectedOrganisationUnit)
             // if list is null, we reload the list. distinctUntilChanged returns false and therefore emits
-            .distinctUntilChanged(([prevState, prevListState], [state, listState]) =>
+            .distinctUntilChanged(([prevState, prevListState], [state, listState]) => 
                 prevState.selectedOrganisationUnit === state.selectedOrganisationUnit && listState.list !== null
             ).subscribe(
-                async ([{ selectedOrganisationUnit, userOrganisationUnitIds }]) => {
+                async ([{ selectedOrganisationUnit, userOrganisationUnitIds }, listState]) => {
                     const d2 = await getInstance();
 
                     if (!selectedOrganisationUnit.id) {
                         return listActions.setListSource(ModelCollection.create(d2.models.organisationUnit));
                     }
 
-                    let organisationUnitList = d2.models.organisationUnit
-                        .filter().on('name').notEqual('default');
-
-                    organisationUnitList = await organisationUnitList
+                    let filteredOrganisationUnitList = d2.models.organisationUnit
                         .filter().on('name').notEqual('default')
                         .filter().on('parent.id').equals(selectedOrganisationUnit.id)
-                        .list({ fields: fieldFilteringForQuery });
+
+                    const fieldsForOrgUnit = getQueryForSchema('organisationUnit').fields;
+                    // Load selectedOrganisationUnit again to get data for fields that may have been changed by configurable columns
+                    const [selectedOrgUnitWithFields, organisationUnitList] = await Promise.all([
+                        d2.models.organisationUnit.get(selectedOrganisationUnit.id, { field: fieldsForOrgUnit}),
+                        filteredOrganisationUnitList.list({ fields: fieldsForOrgUnit })]
+                    );
 
                     // DHIS2-2160 Add the selected node to the list to
                     // avoid having to select the parent node to edit
                     // the selected node...
-                    let prependedOrgUnitList = createPrependedOrgUnitList(selectedOrganisationUnit, organisationUnitList, d2);
+                    let prependedOrgUnitList = createPrependedOrgUnitList(selectedOrgUnitWithFields, organisationUnitList, d2);
                     listActions.setListSource(prependedOrgUnitList);
                 },
                 error => log.error(error)

--- a/src/config/maintenance-models.js
+++ b/src/config/maintenance-models.js
@@ -221,7 +221,7 @@ const typeDetails = {
     },
     locale: {
         columns: [
-            'name',
+            'displayName',
             'locale',
         ],
     },


### PR DESCRIPTION
When the liststore.list changes to null, which is done when updating the list to set the loading state, the special case for org units now reloads the list.

Also added displayName instead of name to Locale-list.