### PR TITLE
DHIS2-5318 fix color and icon picker for option sets

### DIFF
--- a/src/EditModel/option-set/OptionDialogForOptions/AddOptionDialog.component.js
+++ b/src/EditModel/option-set/OptionDialogForOptions/AddOptionDialog.component.js
@@ -19,21 +19,6 @@ class AddOptionDialog extends Component {
         isSaving: false,
     };
 
-    // First the component updates with the new model and dialog state open
-    // But at this stage the fieldConfigs are stale
-    // So it should not update yet - or better still - make sure all three props are set in one go
-
-    // The below at least proves that the above is correct, but is not a proper solution
-    shouldComponentUpdate(nextProps, nextState) {
-        const isOpening = this.props.isDialogOpen === false && nextProps.isDialogOpen === true;
-        const isNotFirstOpening = this.props.model.constructor.name === 'ModelBase';
-        const hasNewModel = this.props.model !== nextProps.model;
-        if (isOpening && isNotFirstOpening && hasNewModel) {
-            return false;
-        }
-        return true;
-    }
-
     onUpdateField = (field, value) => {
         actions.updateModel(this.props.model, field, value);
     }

--- a/src/EditModel/option-set/OptionDialogForOptions/OptionDialogForOptions.component.js
+++ b/src/EditModel/option-set/OptionDialogForOptions/OptionDialogForOptions.component.js
@@ -66,7 +66,7 @@ const optionForm$ = Observable
         optionDialogStore)
     .flatMap(setupFieldConfigs);
 
-const optionFormData$ = Observable.combineLatest(
+const optionFormData$ = Observable.zip(
     optionForm$,
     optionDialogStore,
     (fieldConfigs, optionDialogState) => ({


### PR DESCRIPTION
Use zip which waits until all Observables have emitted a value, instead of combineLatest which responds to a change in any of its Observables. This prevents a state from being set in which the option's model and its fieldConfigs are out of sync