### PR TITLE
v31 - Featuretype override - Remove unused options

### DIFF
--- a/src/config/field-overrides/eventProgramStage.js
+++ b/src/config/field-overrides/eventProgramStage.js
@@ -1,9 +1,19 @@
+import { featureTypeOverride } from './program';
+
 export default new Map([
     [
         'validationStrategy',
         {
             required: true,
             defaultValue: 'ON_COMPLETE',
+        },
+    ],
+    [
+        'featureType',
+        {
+            fieldOptions: {
+                options: featureTypeOverride,
+            },
         },
     ],
 ]);

--- a/src/config/field-overrides/program.js
+++ b/src/config/field-overrides/program.js
@@ -6,6 +6,10 @@ import PeriodTypeDropDown from '../../forms/form-fields/period-type-drop-down';
  * between these two, as they have different behavior and overrides.
  */
 
+
+// The other options from the backend is not used... yet
+export const featureTypeOverride = ['NONE', 'POINT', 'POLYGON'];
+
 const sharedOverrides = new Map([
     [
         'categoryCombo',
@@ -24,6 +28,15 @@ const sharedOverrides = new Map([
             component: PeriodTypeDropDown,
         },
     ],
+    [
+        'featureType',
+        {
+            fieldOptions: {
+                options: featureTypeOverride,
+            },
+        },
+    ],
+
 ]);
 
 export const eventProgram = new Map([...sharedOverrides]);

--- a/src/config/field-overrides/programStage.js
+++ b/src/config/field-overrides/programStage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PeriodTypeDropDown from '../../forms/form-fields/period-type-drop-down';
 import DropDown from '../../forms/form-fields/drop-down';
+import { featureTypeOverride } from './program';
 
 const reportDateOptions = [
     {
@@ -38,6 +39,14 @@ export default new Map([
         'reportDateToUse',
         {
             component: ReportDateToUseDropDown,
+        },
+    ],
+    [
+        'featureType',
+        {
+            fieldOptions: {
+                options: featureTypeOverride,
+            },
         },
     ],
 ]);

--- a/src/config/field-overrides/trackedEntityType.js
+++ b/src/config/field-overrides/trackedEntityType.js
@@ -1,7 +1,19 @@
 import AssignTrackedEntityTypeAttributes from './tracked-entity-type/AssignTrackedEntityTypeAttributes.component';
+import { featureTypeOverride } from './program';
 
 export default new Map([
-    ['trackedEntityTypeAttributes', {
-        component: AssignTrackedEntityTypeAttributes,
-    }],
+    [
+        'trackedEntityTypeAttributes',
+        {
+            component: AssignTrackedEntityTypeAttributes,
+        },
+    ],
+    [
+        'featureType',
+        {
+            fieldOptions: {
+                options: featureTypeOverride
+            },
+        },
+    ],
 ]);


### PR DESCRIPTION
Some options are not used (Multi-polygon and symbol). Markus wanted these gone before release.