### PR TITLE
Use zip instead of combineLatest

### DIFF
--- a/src/EditModel/option-set/OptionDialogForOptions/OptionDialogForOptions.component.js
+++ b/src/EditModel/option-set/OptionDialogForOptions/OptionDialogForOptions.component.js
@@ -66,7 +66,7 @@ const optionForm$ = Observable
         optionDialogStore)
     .flatMap(setupFieldConfigs);
 
-const optionFormData$ = Observable.combineLatest(
+const optionFormData$ = Observable.zip(
     optionForm$,
     optionDialogStore,
     (fieldConfigs, optionDialogState) => ({


### PR DESCRIPTION
Use zip which waits until all Observables have emitted a value instead of combineLatest which responds to a change in any of its Observables. This prevents a state from being set in which the option-model and its fieldConfigs are out of sync