### PR TITLE
Update to new filter name `identifiable` introduced in v2.31

### DIFF
--- a/src/config/custom-models/locale/LocaleModelDefinition.js
+++ b/src/config/custom-models/locale/LocaleModelDefinition.js
@@ -52,7 +52,7 @@ export default class LocaleModelDefinition extends ModelDefinition {
     list() {
         // Read the query string manually from the filters instance because we don't want to transform 
         // it to query parameters for API calls. We will do client side filtering instead. 
-        const nameFilter = this.filters.filters.find(({ propertyName }) => propertyName === 'displayName');
+        const nameFilter = this.filters.filters.find(({ propertyName }) => propertyName === 'identifiable');
         const queryString = nameFilter && nameFilter.filterValue;
 
         return this.getLocalesAndAuthorities()


### PR DESCRIPTION
Filter with name `displayName` was gone, so it was not finding the right filter string