### PR TITLE
DHIS2-5502/Prevent rendering  programstagelist before program is selected

### DIFF
--- a/src/EditModel/SingleModelStore.js
+++ b/src/EditModel/SingleModelStore.js
@@ -72,6 +72,7 @@ export const requestParams = new Map([
     ['programRule', {
         fields: [
             ':all',
+            'program[id,displayName,programType]',
             'programRuleActions[:all',
             'dataElement[id,displayName]',
             'option[id,displayName]',

--- a/src/config/field-overrides/program-rules/programRuleProgramStage.js
+++ b/src/config/field-overrides/program-rules/programRuleProgramStage.js
@@ -26,7 +26,15 @@ class ProgramStageField extends React.Component {
         }
     }
 
+    shouldRender = () => {
+        const props = this.props;
+        const isEventProgram = props.model.program && props.model.program.programType === "WITHOUT_REGISTRATION";
+        return props.model.program && !isEventProgram;
+    }
     render() {
+        if(!this.shouldRender()) {
+            return null;
+        }
         const props = this.props;
         const disabled = !this.state.programId;
         

--- a/src/config/field-overrides/program-rules/programRuleProgramStage.js
+++ b/src/config/field-overrides/program-rules/programRuleProgramStage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import DropdownAsync from '../../../forms/form-fields/drop-down-async';
 import PropTypes from 'prop-types';
+import objectActions from '../../../EditModel/objectActions';
 
 class ProgramStageField extends React.Component {
     constructor(props, context) {
@@ -9,20 +10,29 @@ class ProgramStageField extends React.Component {
         //Need this in state, or else the dropdown will reload all the time, since the
         //filter is a new reference
         this.state = {
-            queryParamFilter: null,
-            programId: null,
+            queryParamFilter: this.getQueryParamFilter(),
+            programId: (props.model.program && props.model.program.id) || null,
         };
+    }
+
+    getQueryParamFilter = (props = this.props) => {
+        if(!props.model.program) {
+            return null;
+        }
+        return [`program.id:eq:${props.model.program.id}`];
     }
 
     componentWillReceiveProps(newProps) {
         const selectedProgram = newProps.model.program;
         if (selectedProgram && selectedProgram.id !== this.state.programId) {
-            const queryParamFilter = [`program.id:eq:${selectedProgram.id}`];
+            const queryParamFilter = this.getQueryParamFilter(newProps);
 
             this.setState({
                 programId: selectedProgram.id,
                 queryParamFilter
             });
+            //Clear programStage when program is changed
+            objectActions.update({fieldName: 'programStage', value: null})
         }
     }
 
@@ -31,17 +41,15 @@ class ProgramStageField extends React.Component {
         const isEventProgram = props.model.program && props.model.program.programType === "WITHOUT_REGISTRATION";
         return props.model.program && !isEventProgram;
     }
+
     render() {
         if(!this.shouldRender()) {
             return null;
         }
-        const props = this.props;
-        const disabled = !this.state.programId;
         
         return (
             <DropdownAsync
-                {...props}
-                disabled={disabled}
+                {...this.props}
                 queryParamFilter={this.state.queryParamFilter}
                 labelText={this.context.d2.i18n.getTranslation(
                     'trigger_rule_only_for_program_stage'


### PR DESCRIPTION
Prevent rendering async programstage-dropdown unless a valid tracker program has been selected.
It's not enough to pass 'disabled', as this will load the options. 

Also added initial values when editing a program rule, to prevent loading every programstage instead of just for the selected program.

Also clears the programstage when program is changed. This can only happen when creating new programrule. This is to prevent this workflow: select program -> select programstage -> select another program. This could result in creating a program rule with a programstage not in the selected program, and it would be hard for the user to recognize this.

See https://jira.dhis2.org/browse/DHIS2-5502.