### PR TITLE
fix(dataentryform): allow input fields that are not elements or attributes

### DIFF
--- a/src/EditModel/event-program/data-entry-form/__tests__/dataEntryFormUtils.spec.js
+++ b/src/EditModel/event-program/data-entry-form/__tests__/dataEntryFormUtils.spec.js
@@ -32,15 +32,34 @@ describe('dataEntryFormUtils', () => {
 
     describe('processForm()', () => {
         test('it should work with empty formData', () => {
+            const dataEntryForm = '';
+            const { usedIds, outHtml } = utils.processFormData(
+                dataEntryForm,
+                elements,
+            );
+            expect(outHtml).toBe(dataEntryForm)
+            expect(usedIds.length).toBe(0)
+        });
+
+        test('it should work with elements', () => {
             const dataEntryForm = initialHTML;
             const { usedIds, outHtml } = utils.processFormData(
                 dataEntryForm,
                 elements,
                 utils.elementPatterns.combinedIdPattern
             );
-            console.log(outHtml);
             expect(outHtml).toBe(initialHTML)
+            expect(usedIds.length).toBe(3)
         });
+
+        test('it should work with input elements that do not have attribute id', () => {
+            const html = initialHTML + '<input type="button" id="a-button">'
+            const { usedIds, outHtml } = utils.processFormData(
+                html,
+                elements,
+            );
+            expect(outHtml).toBe(html)
+        })
     });
 
 });

--- a/src/EditModel/event-program/data-entry-form/dataEntryFormUtils.js
+++ b/src/EditModel/event-program/data-entry-form/dataEntryFormUtils.js
@@ -63,6 +63,7 @@ export function transformElementsToCustomForm(elements) {
  * @returns {*} an object with idString, id and fieldType of the element.
  */
 function getFieldInfoFromMatch(match) {
+    if(!match) return null;
     for(let patternId in matchIndexes) {
         const index = matchIndexes[patternId];
         const elemId = match[index];
@@ -102,10 +103,10 @@ export function processFormData(formData, elements) {
         const inputDisabled = /disabled/.exec(inputHtml) !== null;
 
         const allMatch = allPatterns.exec(inputHtml);
-        const { idString, id, fieldType} = getFieldInfoFromMatch(allMatch)
+        const fieldInfo = getFieldInfoFromMatch(allMatch);
 
-        if (idString && id) {
-         //   console.log(idMatch);
+        if (fieldInfo && fieldInfo.idString && fieldInfo.id) {
+            const { id, fieldType } = fieldInfo;
             usedIds.push(id);
             const label = elements && elements[id];
             const nameAttr = fieldType === "id" ? "entryfield" : null; //used for data-entry
@@ -117,7 +118,6 @@ export function processFormData(formData, elements) {
         inputElement = inputPattern.exec(inHtml);
     }
     outHtml += inHtml.substr(inPos);
-    //console.log(outHtml)
     return {
         usedIds,
         outHtml


### PR DESCRIPTION
See https://jira.dhis2.org/browse/DHIS2-4891

A missing null check caused html tags with "<input" to crash the parser, as they would not have matching attributeids or elementids in the html-attributes.
