### PR TITLE
fix: Remove unused featuretype options

### DIFF
--- a/src/config/field-overrides/eventProgramStage.js
+++ b/src/config/field-overrides/eventProgramStage.js
@@ -1,0 +1,12 @@
+import { featureTypeOverride } from './program';
+
+export default new Map([
+    [
+        'featureType',
+        {
+            fieldOptions: {
+                options: featureTypeOverride,
+            },
+        },
+    ],
+]);

--- a/src/config/field-overrides/index.js
+++ b/src/config/field-overrides/index.js
@@ -30,6 +30,7 @@ import programStage from './programStage';
 import optionGroup from './optionGroup';
 import sqlView from './sqlView';
 import optionGroupSet from './optionGroupSet';
+import eventProgramStage from './eventProgramStage';
 
 const overridesByType = {
     attribute,
@@ -48,6 +49,7 @@ const overridesByType = {
     organisationUnitGroup,
     pushAnalysis,
     eventProgram,
+    eventProgramStage,
     programStage,
     programIndicator,
     programNotificationTemplate,

--- a/src/config/field-overrides/program.js
+++ b/src/config/field-overrides/program.js
@@ -28,6 +28,10 @@ async function getRelationshipTypes(model, d2) {
  * between these two, as they have different behavior and overrides.
  */
 
+
+// The other options from the backend is not used... yet
+export const featureTypeOverride = ['NONE', 'POINT', 'POLYGON'];
+
 const sharedOverrides = new Map([
     [
         'categoryCombo',
@@ -46,6 +50,15 @@ const sharedOverrides = new Map([
             component: PeriodTypeDropDown,
         },
     ],
+    [
+        'featureType',
+        {
+            fieldOptions: {
+                options: featureTypeOverride,
+            },
+        },
+    ],
+
 ]);
 
 export const eventProgram = new Map([...sharedOverrides]);

--- a/src/config/field-overrides/programStage.js
+++ b/src/config/field-overrides/programStage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PeriodTypeDropDown from '../../forms/form-fields/period-type-drop-down';
 import DropDown from '../../forms/form-fields/drop-down';
+import { featureTypeOverride } from './program';
 
 const reportDateOptions = [
     {
@@ -38,6 +39,14 @@ export default new Map([
         'reportDateToUse',
         {
             component: ReportDateToUseDropDown,
+        },
+    ],
+    [
+        'featureType',
+        {
+            fieldOptions: {
+                options: featureTypeOverride,
+            },
         },
     ],
 ]);


### PR DESCRIPTION
Backport of #586 

Note that I did not include featureType in trackedEntityType, since that does not exist in v30 API. 