### PR TITLE
fix: add touch-tap plugin to fix dropdown clicks

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@dhis2/d2-ui-sharing-dialog": "^1.0.12",
     "d2": "30.0.4",
     "d2-ui": "29.0.30",
+    "lodash": "^4.17.11",
     "material-design-icons-iconfont": "^4.0.5",
     "material-ui": "^0.17.0",
     "nyc": "10.1.2",

--- a/src/maintenance.js
+++ b/src/maintenance.js
@@ -16,6 +16,9 @@ import periodTypeStore from './App/periodTypeStore';
 import store from './store';
 import { loadAllColumnsPromise } from './List/columns/epics';
 
+import injectTapEventPlugin from 'react-tap-event-plugin';
+injectTapEventPlugin();
+
 const dhisDevConfig = DHIS_CONFIG; // eslint-disable-line
 
 Error.stackTraceLimit = Infinity;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6912,7 +6912,7 @@ lodash@^4.0.0, lodash@^4.0.1, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.17.10, l
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
   integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
 
-lodash@^4.15.0:
+lodash@^4.15.0, lodash@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==


### PR DESCRIPTION
This adds and inits the touch tap plugin for React 15.5 (has to be version 2.0.1).

Also states lodash as a dependency.