### PR TITLE
fix: add ckeditor dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   "dependencies": {
     "@dhis2/d2-ui-header-bar": "^1.1.4",
     "@dhis2/d2-ui-sharing-dialog": "^1.0.12",
+    "ckeditor": "^4.11.3",
     "d2": "30.0.4",
     "d2-ui": "29.0.30",
     "lodash": "^4.17.11",

--- a/src/EditModel/event-program/data-entry-form/CKEditor.js
+++ b/src/EditModel/event-program/data-entry-form/CKEditor.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { noop } from 'lodash/fp';
 import log from 'loglevel';
 import { Observable } from 'rxjs';
+import CKeditor from 'ckeditor';
 
 export default class CKEditor extends Component {
     constructor(props, context) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2241,6 +2241,11 @@ circular-json@^0.3.1:
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
   integrity sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==
 
+ckeditor@^4.11.3:
+  version "4.11.3"
+  resolved "https://registry.yarnpkg.com/ckeditor/-/ckeditor-4.11.3.tgz#91f66d7ddb5bff3874514fe539779686874ed655"
+  integrity sha512-v6G+v16WAcukKuQH6m+trA9RCOQntFM2nxPO/GFiLYsdD/5IbZAZ2n7GwMxQmxDXpx4AixpnMWF+yAE1t9wq6Q==
+
 clap@^1.0.9:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/clap/-/clap-1.2.3.tgz#4f36745b32008492557f46412d66d50cb99bce51"


### PR DESCRIPTION
The CKEditor script-tag was removed here https://github.com/dhis2/maintenance-app/pull/640/files#diff-11e9f7f953edc64ba14b0cc350ae7b9dL124 . This PR reintroduces it as a npm-module. 
CKEditor 4 does not really support importing, however the index file adds CKeditor to window. 

Might look into CKeditor 5 some time? 