### PR TITLE
fix: validate floating point numbers correctly for legend items

### DIFF
--- a/src/config/field-overrides/legendSet.js
+++ b/src/config/field-overrides/legendSet.js
@@ -64,7 +64,7 @@ export default new Map([
                         const nextStart = Number(nextLegend.startValue);
 
                         // Same values are allowed, but currentEnd can not be bigger than nextStart
-                        return currentEnd < nextStart + 1;
+                        return currentEnd <= nextStart;
                     });
                 },
             },


### PR DESCRIPTION
The original comparison does not work for floating point numbers. This compares correctly for floating point numbers as well.