### PR TITLE
 feat(category combo): default to "None"

### DIFF
--- a/docs/form_config.md
+++ b/docs/form_config.md
@@ -1,0 +1,13 @@
+# Form config
+
+### Fields and field order
+The [field orders](../src/config/field-config/field-order.js)
+determine which field should be shown for a given form.
+
+### Form fields creation
+The `createFieldConfigForModelTypes` function, found in
+[src/EditModel/formHelpers.js](../src/EditModel/formHelpers.js),
+creates the form field components and config for a set of field names.
+
+### Override styles for specific forms
+Here field components and their configs can be [overriden](../src/config/field-overrides/index.js) if a form needs sth different.

--- a/src/EditModel/EditModelForm.component.js
+++ b/src/EditModel/EditModelForm.component.js
@@ -85,6 +85,7 @@ const modelToEditAndModelForm$ = Observable
             fieldConfigs,
             modelToEdit,
         );
+
         const fieldConfigsWithAttributeFields = [].concat(
             fieldConfigsAfterRules,
             // getAttributeFieldConfigs(d2, modelToEdit),
@@ -94,8 +95,10 @@ const modelToEditAndModelForm$ = Observable
                 return config;
             }),
         );
+
         const fieldConfigsWithAttributeFieldsAndUniqueValidators = fieldConfigsWithAttributeFields
             .map(fieldConfig => addUniqueValidatorWhenUnique(fieldConfig, modelToEdit));
+
         return {
             fieldConfigs: fieldConfigsWithAttributeFieldsAndUniqueValidators,
             modelToEdit,

--- a/src/config/field-overrides/dataElement.js
+++ b/src/config/field-overrides/dataElement.js
@@ -6,6 +6,7 @@ export default new Map([
     ['categoryCombo', {
         fieldOptions: {
             queryParamFilter: ['dataDimensionType:eq:DISAGGREGATION', 'name:eq:default'],
+            defaultToDefaultValue: true,
         },
     }],
 ]);

--- a/src/config/field-overrides/dataSet.js
+++ b/src/config/field-overrides/dataSet.js
@@ -8,6 +8,7 @@ export default new Map([
         referenceType: 'categoryCombo',
         fieldOptions: {
             queryParamFilter: ['dataDimensionType:eq:ATTRIBUTE', 'name:eq:default'],
+            defaultToDefaultValue: true,
         },
     }],
     ['periodType', {

--- a/src/config/field-overrides/program.js
+++ b/src/config/field-overrides/program.js
@@ -19,6 +19,7 @@ const sharedOverrides = new Map([
                     'dataDimensionType:eq:ATTRIBUTE',
                     'name:eq:default',
                 ],
+                defaultToDefaultValue: true,
             },
         },
     ],


### PR DESCRIPTION
I added yet another hack to creating form fields. This one sets the value of the category combo to "None" (default) if the field overrides contain an entry for `categoryCombo` which set `defaultToDefaultValue` to `true`