### PR TITLE
fix(program stage): change wording of save btn indicating that nothing is saved

### DIFF
--- a/src/EditModel/SaveButton.component.js
+++ b/src/EditModel/SaveButton.component.js
@@ -38,7 +38,7 @@ SaveButton.propTypes = {
 };
 
 SaveButton.defaultProps = {
-    label: undefined,
+    label: '',
     isSaving: false,
     isValid: true,
 };

--- a/src/EditModel/SaveButton.component.js
+++ b/src/EditModel/SaveButton.component.js
@@ -6,22 +6,41 @@ import addD2Context from 'd2-ui/lib/component-helpers/addD2Context';
 
 function SaveButton(props, { d2 }) {
     const {
+        label,
         isSaving,
         isValid,
         onClick,
         ...rest
     } = props;
-    const buttonText = isSaving ? d2.i18n.getTranslation('saving') : d2.i18n.getTranslation('save');
+
+    const buttonText = label
+        ? label
+        : isSaving 
+            ? d2.i18n.getTranslation('saving') 
+            : d2.i18n.getTranslation('save');
+
     return (
-        <RaisedButton {...rest} primary onClick={onClick} label={buttonText} disabled={isSaving} />
+        <RaisedButton
+            {...rest}
+            primary
+            onClick={onClick}
+            label={buttonText}
+            disabled={isSaving}
+        />
     );
 }
 
 SaveButton.propTypes = {
+    label: PropTypes.string,
     isSaving: PropTypes.bool,
     isValid: PropTypes.bool,
     onClick: PropTypes.func.isRequired,
 };
-SaveButton.defaultProps = { isSaving: false, isValid: true };
+
+SaveButton.defaultProps = {
+    label: undefined,
+    isSaving: false,
+    isValid: true,
+};
 
 export default addD2Context(SaveButton);

--- a/src/EditModel/event-program/__tests__/reducers.spec.js
+++ b/src/EditModel/event-program/__tests__/reducers.spec.js
@@ -32,6 +32,7 @@ describe('Event Program', () => {
                 programStageStepper: {
                     activeStep: stepKey,
                     stageId: null,
+                    mode: 'none',
                 },
             };
 

--- a/src/EditModel/event-program/tracker-program/epics.js
+++ b/src/EditModel/event-program/tracker-program/epics.js
@@ -98,7 +98,7 @@ export const newTrackerProgramStage = action$ =>
                 log.error(e);
                 throw new Error(e);
             }
-            return editProgramStage(programStageUid);
+            return editProgramStage(programStageUid, true);
         }),
     ));
 

--- a/src/EditModel/event-program/tracker-program/program-stages/EditProgramStage.js
+++ b/src/EditModel/event-program/tracker-program/program-stages/EditProgramStage.js
@@ -1,21 +1,25 @@
-import React from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { compose, lifecycle } from 'recompose';
 
-import ProgramStageStepper from './ProgramStageStepper';
+import { getInstance } from 'd2/lib/d2';
 import { withProgramStageFromProgramStage$ } from './utils';
 import { changeStepperDisabledState } from '../../actions';
 import { saveProgramStageEdit, cancelProgramStageEdit, editProgramStageReset } from './actions';
-import FormActionButtons from '../../../FormActionButtons';
+import ProgramStageStepper from './ProgramStageStepper';
+import SaveButton from '../../../SaveButton.component';
+import CancelButton from '../../../CancelButton.component';
 
-const EditProgramStage = (props) => {
+const EditProgramStage = (props, context) => {
     const styles = {
         buttons: {
             padding: '2rem 1rem 1rem',
             marginLeft: '10px',
         },
     };
+
     return (
         <div>
             <ProgramStageStepper
@@ -23,13 +27,35 @@ const EditProgramStage = (props) => {
                 programStage={props.programStage}
             />
             <div style={styles.buttons}>
-                <FormActionButtons
-                    onSaveAction={props.saveProgramStageEdit}
-                    onCancelAction={props.cancelProgramStageEdit}
-                />
+                {props.isEditing &&
+                    <div
+                        style={{
+                            padding: '10px 0',
+                            fontWeight: 'bold',
+                        }}
+                    >
+                        {context.d2.i18n.getTranslation('stage_save_hint_text')}
+                    </div>
+                }
+
+                <div>
+                    <SaveButton
+                        onClick={props.saveProgramStageEdit}
+                        label={context.d2.i18n.getTranslation(
+                            !props.isEditing
+                                ? 'stage_add'
+                                : 'stage_update'
+                        )}
+                    />
+                    <CancelButton onClick={props.cancelProgramStageEdit} style={{ marginLeft: '1rem' }} />
+                </div>
             </div>
         </div>
     );
+}
+
+EditProgramStage.contextTypes = {
+  d2: PropTypes.object,
 };
 
 export default compose(

--- a/src/EditModel/event-program/tracker-program/program-stages/ProgramStage.js
+++ b/src/EditModel/event-program/tracker-program/program-stages/ProgramStage.js
@@ -7,7 +7,10 @@ import ProgramStageList from './ProgramStageList';
 import EditProgramStage from './EditProgramStage';
 import { editProgramStage } from './actions';
 import { getProgramStageById$, firstProgramStage$, withProgramAndStages } from './utils';
-import { getCurrentProgramStageId } from './selectors';
+import { 
+    getCurrentProgramStageId,
+    getIsStageBeingEdited,
+} from './selectors';
 
 class ProgramStage extends Component {
     shouldComponentUpdate(nextProps) {
@@ -41,7 +44,7 @@ class ProgramStage extends Component {
 
 const mapStateToProps = state => ({
     currentProgramStageId: getCurrentProgramStageId(state),
-    isEditing: state.eventProgram.programStageStepper.mode === 'edit',
+    isEditing: getIsStageBeingEdited(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/EditModel/event-program/tracker-program/program-stages/ProgramStage.js
+++ b/src/EditModel/event-program/tracker-program/program-stages/ProgramStage.js
@@ -26,7 +26,10 @@ class ProgramStage extends Component {
         return (
             <div>
                 {this.props.currentProgramStageId
-                    ? <EditProgramStage programStage$={programStage$} />
+                    ? <EditProgramStage
+                        programStage$={programStage$}
+                        isEditing={props.isEditing}
+                    />
                     : <ProgramStageList
                         program={props.program}
                         programStages={props.programStages}
@@ -38,6 +41,7 @@ class ProgramStage extends Component {
 
 const mapStateToProps = state => ({
     currentProgramStageId: getCurrentProgramStageId(state),
+    isEditing: state.eventProgram.programStageStepper.mode === 'edit',
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/EditModel/event-program/tracker-program/program-stages/__tests__/programStageReducer.spec.js
+++ b/src/EditModel/event-program/tracker-program/program-stages/__tests__/programStageReducer.spec.js
@@ -13,6 +13,7 @@ describe('ProgramStage Reducer', () => {
         iterator.first = jest.fn();
 
         intialState = {
+            mode: 'none',
             activeStep: iterator.first(steps),
             stageId: null,
         };
@@ -103,6 +104,7 @@ describe('ProgramStage Reducer', () => {
 
             const expectedState = {
                 ...intialState,
+                mode: 'edit',
                 stageId,
             };
             expect(
@@ -110,6 +112,26 @@ describe('ProgramStage Reducer', () => {
                     type: programActions.PROGRAM_STAGE_EDIT,
                     payload: {
                         stageId,
+                        addNewStage: false,
+                    },
+                }),
+            ).toEqual(expectedState);
+        });
+
+        test('it should handle PROGRAM_STAGE_EDIT with adding a new one', () => {
+            const stageId = 'Dos';
+
+            const expectedState = {
+                ...intialState,
+                mode: 'add',
+                stageId,
+            };
+            expect(
+                reducer(intialState, {
+                    type: programActions.PROGRAM_STAGE_EDIT,
+                    payload: {
+                        stageId,
+                        addNewStage: true,
                     },
                 }),
             ).toEqual(expectedState);

--- a/src/EditModel/event-program/tracker-program/program-stages/actions.js
+++ b/src/EditModel/event-program/tracker-program/program-stages/actions.js
@@ -27,9 +27,9 @@ export const changeStep = stepKey => ({
 export const nextStep = () => ({ type: PROGRAM_STAGE_STEP_NEXT });
 export const previousStep = () => ({ type: PROGRAM_STAGE_STEP_PREVIOUS });
 
-export const editProgramStage = stageId => ({
+export const editProgramStage = (stageId, addNewStage = false) => ({
     type: PROGRAM_STAGE_EDIT,
-    payload: { stageId },
+    payload: { stageId, addNewStage },
 });
 
 export const addProgramStage = () => ({

--- a/src/EditModel/event-program/tracker-program/program-stages/reducer.js
+++ b/src/EditModel/event-program/tracker-program/program-stages/reducer.js
@@ -10,7 +10,12 @@ import steps from './programStageSteps';
 import { next, previous, first } from '../../../stepper/stepIterator';
 
 export function programStageStepperReducer(
-    state = { activeStep: first(steps), stageId: null },
+    state = {
+        activeStep:
+        first(steps),
+        stageId: null,
+        mode: 'none',
+    },
     action,
 ) {
     switch (action.type) {
@@ -42,6 +47,9 @@ export function programStageStepperReducer(
         return {
             ...state,
             stageId: action.payload.stageId,
+            mode: action.payload.addNewStage
+                ? 'add'
+                : 'edit',
         };
 
     case PROGRAM_STAGE_EDIT_RESET:
@@ -49,6 +57,7 @@ export function programStageStepperReducer(
             ...state,
             activeStep: first(steps),
             stageId: null,
+            mode: 'none',
         };
     default:
         break;

--- a/src/EditModel/event-program/tracker-program/program-stages/selectors.js
+++ b/src/EditModel/event-program/tracker-program/program-stages/selectors.js
@@ -23,5 +23,7 @@ export const getStageSectionsById = curry((state, id) => {
     return get(id, programStageSections);
 });
 
+export const getIsStageBeingEdited = state =>
+    state.eventProgram.programStageStepper.mode === 'edit';
 
 export const getMaxSortOrder = (store) => (store.programStages.reduce((max, curr) => Math.max(max, curr.sortOrder), 0));

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -2238,3 +2238,6 @@ enable_user_assignment=Allow user assignment of events
 output_combo=Output category combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options
+stage_save_hint_text=An updated program stage is not saved until the program itself is saved. Not saving the program will discard all changes made to the program stage.
+stage_add=Add stage
+stage_update=Update stage


### PR DESCRIPTION
The button text changed from "Save" to "Add stage" / "Update stage", depending on the scenario.
It also says "Update stage" when a stage, that was added during creation of a new tracker program, is being edited.

Furthermore, for clarification to the end user, I included a paragraph when editing a stage, to inform the user that clicking "Update stage" will not save the stage, but the program has to be saved in order to save the stage as well.

> An updated program stage is not saved until the program itself is saved. Not saving the program will discard all changes made to the program stage.