### PR TITLE
DHIS2-2665 unset output combo when DE changes or no value is selected

### DIFF
--- a/src/config/field-overrides/predictor/DataElementCategoryOptionCombo.js
+++ b/src/config/field-overrides/predictor/DataElementCategoryOptionCombo.js
@@ -42,18 +42,25 @@ class DataElementCategoryOptionCombo extends Component {
     };
 
     componentDidMount() {
-        if (this.hasModelOutputId()) {
+        const currModelOutputId = this.getModelOutputId();
+
+        if (currModelOutputId) {
             this.fetchOptions();
-            this.prevOutputId = this.props.model.output.id;
+            this.prevOutputId = currModelOutputId;
         }
     }
 
     componentDidUpdate() {
-        if (
-            this.hasModelOutputId() &&
-            this.props.model.output.id !== this.prevOutputId
-        ) {
-            this.fetchOptions();
+        const currModelOutputId = this.getModelOutputId();
+
+        if (currModelOutputId !== this.prevOutputId) {
+            // Clear value of outputCombo when dataElement changes
+            this.props.onChange({ target: { value: null } });
+
+            if (currModelOutputId) {
+                // fetch options for new dataElement (model.output.id)
+                this.fetchOptions();
+            }
         }
 
         this.prevOutputId = this.props.model.output
@@ -61,9 +68,11 @@ class DataElementCategoryOptionCombo extends Component {
             : null;
     }
 
-    hasModelOutputId() {
+    getModelOutputId() {
         const model = this.props.model;
-        return !!(model && model.output && model.output.id);
+        return model && model.output && model.output.id
+            ? model.output.id
+            : null;
     }
 
     async fetchOptions() {

--- a/src/config/field-overrides/predictor/DataElementCategoryOptionCombo.js
+++ b/src/config/field-overrides/predictor/DataElementCategoryOptionCombo.js
@@ -36,9 +36,9 @@ class DataElementCategoryOptionCombo extends Component {
     // By keeping track of this string literal the changes are detected correctly.
     prevOutputId = null;
 
-    onChange = event => {
-        const fakeEvent = { target: { value: { id: event.target.value } } };
-        this.props.onChange(fakeEvent);
+    onChange = ({ target }) => {
+        const value = target.value ? { id: target.value } : null;
+        this.props.onChange({ target: { value } });
     };
 
     componentDidMount() {
@@ -119,7 +119,7 @@ class DataElementCategoryOptionCombo extends Component {
             <DropDown
                 labelText={this.getTranslation('output_combo')}
                 onChange={this.onChange}
-                value={this.props.value.id}
+                value={this.props.value && this.props.value.id}
                 options={this.state.options}
             />
         );
@@ -133,7 +133,7 @@ DataElementCategoryOptionCombo.propTypes = {
 };
 
 DataElementCategoryOptionCombo.defaultProps = {
-    value: { id: null },
+    value: null,
 };
 
 DataElementCategoryOptionCombo.contextTypes = {


### PR DESCRIPTION
This is a fix on https://github.com/dhis2/maintenance-app/pull/672 which had already been merged. This PR addresses 2 problems:
1. When selecting "No value" in the dropdown, I was calling `this.props.onChange` with this as a value `{ id: null }`. This was wrong, it should have been `null`. This problem would result in an error when clicking save after selecting "No value"
1. The list of "Output category combos" is only relevant in the context of a particular dataElement. As such, the `outputCombo` needs to be cleared whenever the selected dataElement changes. I have added that step now.