### PR TITLE
refactor: remove short name fields that are not persisted in the database

### DIFF
--- a/src/config/field-config/field-order.js
+++ b/src/config/field-config/field-order.js
@@ -169,7 +169,6 @@ const fieldOrderByName = new Map([
     ]],
     ['organisationUnitGroupSet', [
         'name',
-        'shortName',
         'code',
         'description',
         'compulsory',

--- a/src/config/field-config/field-order.js
+++ b/src/config/field-config/field-order.js
@@ -27,7 +27,6 @@ const fieldOrderByName = new Map([
     ]],
     ['dataElementGroupSet', [
         'name',
-        'shortName',
         'code',
         'description',
         'compulsory',

--- a/src/config/field-config/field-order.js
+++ b/src/config/field-config/field-order.js
@@ -35,7 +35,6 @@ const fieldOrderByName = new Map([
     ]],
     ['category', [
         'name',
-        'shortName',
         'code',
         'description',
         'dataDimensionType',


### PR DESCRIPTION
Removes the fields for "Data Element Group Set", "Category" and "OrganisationUnitGroupSet".

Fixes DHIS2-6362