### PR TITLE
refactor: remove short name fields that are not persisted in the databae

### DIFF
--- a/src/config/field-config/field-order.js
+++ b/src/config/field-config/field-order.js
@@ -26,7 +26,6 @@ const fieldOrderByName = new Map([
     ]],
     ['dataElementGroupSet', [
         'name',
-        'shortName',
         'code',
         'description',
         'compulsory',
@@ -35,7 +34,6 @@ const fieldOrderByName = new Map([
     ]],
     ['category', [
         'name',
-        'shortName',
         'code',
         'description',
         'dataDimensionType',
@@ -169,7 +167,6 @@ const fieldOrderByName = new Map([
     ]],
     ['organisationUnitGroupSet', [
         'name',
-        'shortName',
         'code',
         'description',
         'compulsory',


### PR DESCRIPTION
Remove from: Data Element Group Set, Category & Organisation Unit Group Set
Fixes DHIS2-6362