### PR TITLE
refactor: remove short name fields that are not persisted in the database

### DIFF
--- a/src/config/field-config/field-order.js
+++ b/src/config/field-config/field-order.js
@@ -27,7 +27,6 @@ const fieldOrderByName = new Map([
     ]],
     ['dataElementGroupSet', [
         'name',
-        'shortName',
         'code',
         'description',
         'compulsory',
@@ -36,7 +35,6 @@ const fieldOrderByName = new Map([
     ]],
     ['category', [
         'name',
-        'shortName',
         'code',
         'description',
         'dataDimensionType',
@@ -171,7 +169,6 @@ const fieldOrderByName = new Map([
     ]],
     ['organisationUnitGroupSet', [
         'name',
-        'shortName',
         'code',
         'description',
         'compulsory',


### PR DESCRIPTION
Remove from: Data Element Group Set, Category & Organisation Unit Group Set
Fixes DHIS2-6362