### PR TITLE
fix: open orgunit configcolumns-dialog

### DIFF
--- a/src/App/App.component.js
+++ b/src/App/App.component.js
@@ -97,8 +97,6 @@ class App extends AppWithD2 {
                         </SinglePanelLayout>
                     )}
                     <SnackbarContainer />
-                    <DialogRouter groupName={this.props.params.groupName}
-                        modelType={this.props.params.modelType} />
                 </div>
             </Provider>
         );

--- a/src/List/List.component.js
+++ b/src/List/List.component.js
@@ -38,7 +38,7 @@ import IconButton from 'material-ui/IconButton/IconButton';
 import FontIcon from 'material-ui/FontIcon/FontIcon';
 import { connect } from 'react-redux';
 import { openColumnsDialog } from './columns/actions';
-import ColumnConfigDialog from './columns/ColumnConfigDialog';
+import DialogRouter from '../Dialog/DialogRouter';
 import ContextMenuHeader from './ContextMenuHeader'
 import { openDialog } from '../Dialog/actions';
 import * as DIALOGTYPES from '../Dialog/types';
@@ -645,6 +645,8 @@ class List extends Component {
                     onRequestClose={this.closeDataElementOperandDialog}
                 />
                 {this.state.predictorDialog && <PredictorDialog />}
+                <DialogRouter groupName={this.props.params.groupName}
+                        modelType={this.props.params.modelType} />
             </div>
         );
     }


### PR DESCRIPTION
A bit of a workaround, as we don't have the modelType for orgunits until the list.
If we refactor more dialogs to use the DialogRouter - we should move this back to App-component.