### PR TITLE
fix(expression validation): translate message when endpoint responds with 500

### DIFF
--- a/src/utils/createActionToValidation$.js
+++ b/src/utils/createActionToValidation$.js
@@ -6,7 +6,10 @@ export const createActionToValidation$ = url => ({data}) => {
     const request = getD2()
         .then(d2 => d2.Api.getApi())
         .then(api => api.post(url, data, options))
-        .catch(e => ({ ...e, message: 'Expression is empty' }))
+        .catch(e => getD2().then(d2 => ({
+            ...e,
+            message: d2.i18n.getTranslation('Expression is empty'),
+        })))
 
     return Observable.fromPromise(request);
 };


### PR DESCRIPTION
With this change the workaround for the 500 response will be translated properly
([related JIRA issue](https://jira.dhis2.org/browse/TECH-200?focusedCommentId=26615&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-26615))