### PR TITLE
fix: backport feature type override fix to v30

### DIFF
--- a/src/config/field-overrides/eventProgramStage.js
+++ b/src/config/field-overrides/eventProgramStage.js
@@ -9,4 +9,12 @@ export default new Map([
             },
         },
     ],
+    [
+        'featureType',
+        {
+            fieldOptions: {
+                options: featureTypeOverride,
+            },
+        },
+    ],
 ]);

--- a/src/config/field-overrides/trackedEntityType.js
+++ b/src/config/field-overrides/trackedEntityType.js
@@ -1,7 +1,19 @@
 import AssignTrackedEntityTypeAttributes from './tracked-entity-type/AssignTrackedEntityTypeAttributes.component';
+import { featureTypeOverride } from './program';
 
 export default new Map([
-    ['trackedEntityTypeAttributes', {
-        component: AssignTrackedEntityTypeAttributes,
-    }],
+    [
+        'trackedEntityTypeAttributes',
+        {
+            component: AssignTrackedEntityTypeAttributes,
+        },
+    ],
+    [
+        'featureType',
+        {
+            fieldOptions: {
+                options: featureTypeOverride
+            },
+        },
+    ],
 ]);


### PR DESCRIPTION
I am confused by what I am seeing here:
- For DHIS2-5419 I have found a PR against master https://github.com/dhis2/maintenance-app/pull/586 and against v31 https://github.com/dhis2/maintenance-app/pull/585 but not against v30
- So I created a new branch from v30 and cherry picked the changes from commit 1839ec0d981d626196381a50deb98a47ca10021f (which was the only commit in https://github.com/dhis2/maintenance-app/pull/586)
- And now I expected to see the same changes in 4 files as I saw in https://github.com/dhis2/maintenance-app/pull/586, but only a subset of these is showing up here...

So now my question is: 
a) Was the rest of this code already merged into v30 somehow, and were these two changes omitted deliberately?
b) Shall we proceed with this PR and merge these two changes into v30 too?
