### PR TITLE
fix(org-units): fetch full parent node to display details in list

### DIFF
--- a/src/List/organisation-unit-list/OrganisationUnitList.component.js
+++ b/src/List/organisation-unit-list/OrganisationUnitList.component.js
@@ -54,18 +54,22 @@ export default class OrganisationUnitList extends React.Component {
                         return listActions.setListSource(ModelCollection.create(d2.models.organisationUnit));
                     }
 
-                    let organisationUnitList = d2.models.organisationUnit
-                        .filter().on('name').notEqual('default');
+                    const [fullSelectedOrganisationUnit, childrenList] = await Promise.all([
+                        // The d2-ui orgUnitTree component uses d2.models.organisationUnit instances with only a few properties
+                        // We need more properties to display the item details next to the list, so we fetch a fuller version of the model instance
+                        d2.models.organisationUnit
+                            .get(selectedOrganisationUnit.id, { fields: fieldFilteringForQuery}),
 
-                    organisationUnitList = await organisationUnitList
-                        .filter().on('name').notEqual('default')
-                        .filter().on('parent.id').equals(selectedOrganisationUnit.id)
-                        .list({ fields: fieldFilteringForQuery });
+                        d2.models.organisationUnit
+                            .filter().on('name').notEqual('default')
+                            .filter().on('parent.id').equals(selectedOrganisationUnit.id)
+                            .list({ fields: fieldFilteringForQuery })
+                    ])
 
                     // DHIS2-2160 Add the selected node to the list to
                     // avoid having to select the parent node to edit
                     // the selected node...
-                    let prependedOrgUnitList = createPrependedOrgUnitList(selectedOrganisationUnit, organisationUnitList, d2);
+                    let prependedOrgUnitList = createPrependedOrgUnitList(fullSelectedOrganisationUnit, childrenList, d2);
                     listActions.setListSource(prependedOrgUnitList);
                 },
                 error => log.error(error)


### PR DESCRIPTION
This was only going wrong in v30. It was "fixed" in higher versions when the _configurable columns_ were introduced in https://github.com/dhis2/maintenance-app/pull/581/. In the higher versions, the selectedOrganisationUnit is fetched with the correct fields every time. This is to make sure that all the fields that have been configured are also present on the model. And as a by-product this also fixed the detail-view.
https://github.com/dhis2/maintenance-app/blob/d40dbccd862ac64c21b4e22edf829c0d9e471c3c/src/List/organisation-unit-list/OrganisationUnitList.component.js#L66-L70

So, since dhis2-core v30 doesn't support configurable columns, this "happy accident" never happened here. So the current PR is for v30 only, and makes sure that all the detail fields are present on the selectedOrganisationUnit model.