### PR TITLE
Dhis2 6980/prevent saving coordinate field

### DIFF
--- a/src/EditModel/form-helpers/validateFields.js
+++ b/src/EditModel/form-helpers/validateFields.js
@@ -27,8 +27,8 @@ const validateField = (field, formRef, formRefStateClone) => {
  * Adds the step that the field can be found on (if present).
  */
 const getErrorMessage = (field) => {
-    const fieldStep = field.step ? `On step ${field.step}` : '';
-    const errorMessage = `${field.message} : ${field.name}. ${fieldStep}`;
+    const fieldStep = field.step ? `: ${field.name}. On step ${field.step}` : '';
+    const errorMessage = `${field.message}${fieldStep}`;
     return errorMessage;
 };
 

--- a/src/config/field-overrides/organisationUnit.js
+++ b/src/config/field-overrides/organisationUnit.js
@@ -1,6 +1,6 @@
 import { isStartDateBeforeEndDate } from 'd2-ui/lib/forms/Validators';
 import OrgUnitSelectDialogField from '../../forms/form-fields/orgunit-select-dialog-field';
-import CoordinateField from '../../forms/form-fields/coordinate-field';
+import CoordinateField, { validators as coordinateValidators } from '../../forms/form-fields/coordinate-field';
 
 export default new Map([
     [
@@ -16,6 +16,7 @@ export default new Map([
         'coordinates', {
             component: CoordinateField,
             fieldOptions: {},
+            validators: coordinateValidators,
         },
     ],
     [

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -2202,3 +2202,4 @@ confirm_delete_option_group=Do you want to delete this option group?
 stage_save_hint_text=An updated program stage is not saved until the program itself is saved. Not saving the program will discard all changes made to the program stage.
 stage_add=Add stage
 stage_update=Update stage
+invalid_coordinate=Invalid coordinate


### PR DESCRIPTION
It was not possible to backport this (#695), due to an API change. However, I did some refactoring to simplify the state, so it should be able to validate and prevent saving now.

This will add validation and prevent saving when coordinates are invalid.

Should fix https://jira.dhis2.org/browse/DHIS2-6980 for v31 and v30 (#722).

Note that if you test this,  you need to test it against 2.30 or 2.31 backend, or else the fields won't show due to the API-change.