### PR TITLE
fixz(program sections): rename program sections step

### DIFF
--- a/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/AssignAttributes.js
+++ b/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/AssignAttributes.js
@@ -40,6 +40,7 @@ import {
 const styles = {
     groupEditor: {
         padding: '2rem 3rem 4rem',
+        marginTop: '15px'
     },
     fieldname: {
         fontSize: 16,

--- a/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/AttributesStepper.js
+++ b/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/AttributesStepper.js
@@ -5,6 +5,7 @@ import { createStepperFromConfig } from '../../../stepper/stepper';
 import AssignAttributes from './AssignAttributes';
 import CreateEnrollmentDataEntryForm from './data-entry-form/CreateEnrollmentDataEntryForm';
 import { withAttributes } from './AssignAttributes';
+
 const steps = [
     {
         key: 'assign_attributes',
@@ -12,8 +13,8 @@ const steps = [
         componentName: 'AssignAttributes',
     },
     {
-        key: 'create_data_entry_form',
-        name: 'create_data_entry_form',
+        key: 'create_registration_form',
+        name: 'create_registration_form',
         componentName: 'CreateEnrollmentDataEntryForm',
     },
 ]

--- a/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/data-entry-form/CreateEnrollmentDataEntryForm.js
+++ b/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/data-entry-form/CreateEnrollmentDataEntryForm.js
@@ -70,7 +70,7 @@ class CreateEnrollmentDataEntryForm extends Component {
 
     render() {
         return (
-            <Paper>
+            <Paper style = {{marginTop: '15px'}}>
                 <Tabs
                     initialSelectedIndex={this.state.curTab}
                     onChange={this.onTabChange}

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -2249,3 +2249,4 @@ add_new_section=Add new section
 update_section=Update section
 no_attributes=No attributes selected
 no_data_elements=No data elements selected
+create_registration_form=Create registration form


### PR DESCRIPTION
Renamed 'Create data entry form' to 'Create registration form' as this better describes what the form is used for.
Added margin for stepper-content, as the stepper-button was overlapping with the content.