### PR TITLE
fix: ignore polygons in coordinate validation

### DIFF
--- a/src/forms/form-fields/coordinate-field.js
+++ b/src/forms/form-fields/coordinate-field.js
@@ -66,7 +66,7 @@ class CoordinateField extends React.Component {
     handleLongitude = (event) => {
         const long = event.target.value.length > 0 ? event.target.value : undefined;
         const longError = !long || isValidLongitude(long) ? undefined: this.getTranslation(isValidLongitude.message)
-       
+
         this.setState({ longError });
         this.updateLatLong(this.getLatitude(), long);
     }
@@ -122,15 +122,24 @@ export const validators = [
     {
         validator(value) {
             let coords = value
+
             try {
                 coords = value ? JSON.parse(value) : null
             } catch(e) {
                 return false;
             }
+
             if (!coords) {
                 return true
             }
-            
+
+            // If true, coordinates are a polygon and can't be edited
+            // anyways. Return "valid: true" to not block editing
+            // of polygon org units
+            if (!isPoint(coords)) {
+                return true
+            }
+
             const [long, lat] = coords;
             return isValidLongitude(long) && isValidLatitude(lat);
         },


### PR DESCRIPTION
**Bug description:**
In version 2.31dev, it's currently not possible to save organisation units that have a polygon as coordinate (e. g. [`BO`](https://debug.dhis2.org/2.31dev/dhis-web-maintenance/index.html#/edit/organisationUnitSection/organisationUnit/O6uvpzGd5pu)), even if nothing in the form has changed.

**Fix description:**
This will make it possible to edit org unit with polygon coordinates, which are not editable in the maintennace app, by skipping validation of coordinates when the coordinates are a polygon.

**Note for testing:**
You have to use the v31 backend.
Check your `$DHIS2_HOME/config.json`, I've used:
```json
{
    "baseUrl": "https://debug.dhis2.org/2.31dev",
    ...
}
```