### PR TITLE
feat: nextScheduleDate-field

### DIFF
--- a/src/EditModel/SingleModelStore.js
+++ b/src/EditModel/SingleModelStore.js
@@ -57,7 +57,7 @@ export const requestParams = new Map([
             'attributeValues[:all,attribute[id,name,displayName]]',
             'organisationUnits[id,path]',
             'dataEntryForm[:owner]',
-            'programStages[:owner,notificationTemplates[displayName,:owner]]',
+            'programStages[:owner,notificationTemplates[displayName,:owner],nextScheduleDate[id,displayName]]',
             'notificationTemplates[:owner]',
         ].join(','),
     }],

--- a/src/EditModel/event-program/assign-data-elements/__tests__/epics.spec.js
+++ b/src/EditModel/event-program/assign-data-elements/__tests__/epics.spec.js
@@ -90,6 +90,7 @@ describe('Assign data elements epics', () => {
                         expect(isValidUid(newlyAddedDataElement.id)).toBe(true);
                         expect(newlyAddedDataElement.dataElement).toEqual({
                             id: availableDataElementA.id,
+                            displayName: availableDataElementA.displayName,
                             optionSet: availableDataElementA.optionSet,
                             valueType: availableDataElementA.valueType,
                         });
@@ -119,11 +120,13 @@ describe('Assign data elements epics', () => {
 
                         expect(newlyAddedDataElementOne.dataElement).toEqual({
                             id: availableDataElementA.id,
+                            displayName: availableDataElementA.displayName,
                             optionSet: availableDataElementA.optionSet,
                             valueType: availableDataElementA.valueType,
                         });
                         expect(newlyAddedDataElementTwo.dataElement).toEqual({
                             id: availableDataElementB.id,
+                            displayName: availableDataElementB.displayName,
                             optionSet: availableDataElementB.optionSet,
                             valueType: availableDataElementB.valueType,
                         });

--- a/src/EditModel/event-program/assign-data-elements/epics.js
+++ b/src/EditModel/event-program/assign-data-elements/epics.js
@@ -63,11 +63,12 @@ const addDataElementsToStage = store => action$ =>
             let sortOrder = programStageDataElements.length;
             const programStageDataElementsToAdd = map((id) => {
                 sortOrder += 1;
-                const { optionSet, valueType } = state.availableDataElements.find(dataElement => dataElement.id === id);
+                const { optionSet, valueType, displayName } = state.availableDataElements.find(dataElement => dataElement.id === id);
                 return {
                     id: generateUid(),
                     dataElement: {
                         id,
+                        displayName,
                         optionSet,
                         valueType,
                     },

--- a/src/config/field-config/field-order.js
+++ b/src/config/field-config/field-order.js
@@ -277,6 +277,7 @@ const fieldOrderByName = new Map([
         'periodType',
         'displayGenerateEventBox',
         'standardInterval',
+        'nextScheduleDate',
         'autoGenerateEvent',
         'openAfterEnrollment',
         'reportDateToUse',

--- a/src/config/field-overrides/programStage.js
+++ b/src/config/field-overrides/programStage.js
@@ -37,12 +37,13 @@ const NextScheduleDateField = props => {
             value: psde.dataElement,
         }));
 
-    let value = undefined;
-    if (props.model.nextScheduleDate) {
-        value = dataElementsOptions
-            .filter(opts => opts.value.id === props.model.nextScheduleDate.id)
-            .map(v => v.value)[0];
-    }
+    const selectedDEO =
+        props.model.nextScheduleDate &&
+        dataElementsOptions.find(
+            opts => opts.value.id === props.model.nextScheduleDate.id
+        );
+
+    const value = selectedDEO && selectedDEO.value;
 
     return <DropDown {...props} options={dataElementsOptions} value={value} />;
 };

--- a/src/config/field-overrides/programStage.js
+++ b/src/config/field-overrides/programStage.js
@@ -25,8 +25,27 @@ const reportDateOptions = [
  *  or translateOptions through fieldOptions to the DropDown-component.
  */
 
-const ReportDateToUseDropDown = props =>
-    <DropDown {...props} options={reportDateOptions} translateOptions />;
+const ReportDateToUseDropDown = props => (
+    <DropDown {...props} options={reportDateOptions} translateOptions />
+);
+
+const NextScheduleDateField = props => {
+    const dataElementsOptions = props.model.programStageDataElements
+        .filter(psde => psde.dataElement.valueType === 'DATE')
+        .map(psde => ({
+            text: psde.dataElement.displayName,
+            value: psde.dataElement,
+        }));
+
+    let value = undefined;
+    if (props.model.nextScheduleDate) {
+        value = dataElementsOptions
+            .filter(opts => opts.value.id === props.model.nextScheduleDate.id)
+            .map(v => v.value)[0];
+    }
+
+    return <DropDown {...props} options={dataElementsOptions} value={value} />;
+};
 
 export default new Map([
     [
@@ -47,6 +66,12 @@ export default new Map([
             fieldOptions: {
                 options: featureTypeOverride,
             },
+        },
+    ],
+    [
+        'nextScheduleDate',
+        {
+            component: NextScheduleDateField,
         },
     ],
 ]);

--- a/src/forms/form-fields/drop-down.js
+++ b/src/forms/form-fields/drop-down.js
@@ -82,7 +82,7 @@ class Dropdown extends Component {
             .map(option => (
                 <MenuItem
                     primaryText={option.text}
-                    key={option.value}
+                    key={option.text}
                     value={option.value}
                     label={option.text}
                 />

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -2250,3 +2250,4 @@ update_section=Update section
 no_attributes=No attributes selected
 no_data_elements=No data elements selected
 create_registration_form=Create registration form
+next_schedule_date=Default next scheduled date


### PR DESCRIPTION
Support for nextScheduleDate-field. See [DHIS2-6268](https://jira.dhis2.org/browse/DHIS2-6268)

I went for using a plain DropDown. Could have used DropDownAsync, but as we already have the data it's redudant, and you if you add a new DataElement to the stage this would not be included if you went back to check the dropdown, since the data is not posted until you save the entire program.

The code for the dropdown-component is messy... This seems like the first time we use the dropdown for object-values, so I changed the "key" of the rendered options to be the text of the option instead of the value. Text should be unique within a dropdown anyway.