### PR TITLE
fix(predictors): set unique: false to prevent async validation

### DIFF
--- a/src/config/field-overrides/predictor.js
+++ b/src/config/field-overrides/predictor.js
@@ -152,6 +152,9 @@ export default new Map([
                 message: 'expression_is_required',
             },
         ],
+        // Override unique, it was set to true on the backend for an unkown reason
+        // see https://jira.dhis2.org/browse/DHIS2-8311
+        unique: false
     }],
     ['sampleSkipTest', {
         component: ExpressionField,
@@ -165,5 +168,7 @@ export default new Map([
                 message: 'expression_is_required',
             },
         ],
+        // see https://jira.dhis2.org/browse/DHIS2-8311
+        unique: false
     }],
 ]);


### PR DESCRIPTION
This was caused due to schema changes. `unique` in the schema was set to `true`, resulting in the form trying to validate an object as an unique string.


For reference, this is the commit that changed it: https://github.com/dhis2/dhis2-core/commit/5cba1832518a8c9870ffc9cec4e4639a674e92e9#diff-9724b46626b8d674f9cbca5f0c3251afR22