### PR TITLE
fix: rename "output category combo" to "output category option combo"

### DIFF
--- a/src/i18n/i18n_module_ar.properties
+++ b/src/i18n/i18n_module_ar.properties
@@ -2180,6 +2180,6 @@ stage_save_hint_text=An updated program stage is not saved until the program its
 stage_add=Add stage
 stage_update=Update stage
 invalid_coordinate=Invalid coordinate
-output_combo=Output category combo
+output_combo=Output category option combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -2180,6 +2180,6 @@ stage_save_hint_text=An updated program stage is not saved until the program its
 stage_add=Add stage
 stage_update=Update stage
 invalid_coordinate=Invalid coordinate
-output_combo=Output category combo
+output_combo=Output category option combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options

--- a/src/i18n/i18n_module_es.properties
+++ b/src/i18n/i18n_module_es.properties
@@ -2180,6 +2180,6 @@ stage_save_hint_text=An updated program stage is not saved until the program its
 stage_add=Add stage
 stage_update=Update stage
 invalid_coordinate=Invalid coordinate
-output_combo=Output category combo
+output_combo=Output category option combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options

--- a/src/i18n/i18n_module_fr.properties
+++ b/src/i18n/i18n_module_fr.properties
@@ -2180,6 +2180,6 @@ stage_save_hint_text=An updated program stage is not saved until the program its
 stage_add=Add stage
 stage_update=Update stage
 invalid_coordinate=Invalid coordinate
-output_combo=Output category combo
+output_combo=Output category option combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options

--- a/src/i18n/i18n_module_id.properties
+++ b/src/i18n/i18n_module_id.properties
@@ -2180,6 +2180,6 @@ stage_save_hint_text=An updated program stage is not saved until the program its
 stage_add=Add stage
 stage_update=Update stage
 invalid_coordinate=Invalid coordinate
-output_combo=Output category combo
+output_combo=Output category option combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options

--- a/src/i18n/i18n_module_lo.properties
+++ b/src/i18n/i18n_module_lo.properties
@@ -2180,6 +2180,6 @@ stage_save_hint_text=An updated program stage is not saved until the program its
 stage_add=Add stage
 stage_update=Update stage
 invalid_coordinate=Invalid coordinate
-output_combo=Output category combo
+output_combo=Output category option combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options

--- a/src/i18n/i18n_module_my.properties
+++ b/src/i18n/i18n_module_my.properties
@@ -2180,6 +2180,6 @@ stage_save_hint_text=An updated program stage is not saved until the program its
 stage_add=Add stage
 stage_update=Update stage
 invalid_coordinate=Invalid coordinate
-output_combo=Output category combo
+output_combo=Output category option combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options

--- a/src/i18n/i18n_module_prs.properties
+++ b/src/i18n/i18n_module_prs.properties
@@ -2180,6 +2180,6 @@ stage_save_hint_text=An updated program stage is not saved until the program its
 stage_add=Add stage
 stage_update=Update stage
 invalid_coordinate=Invalid coordinate
-output_combo=Output category combo
+output_combo=Output category option combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options

--- a/src/i18n/i18n_module_pt.properties
+++ b/src/i18n/i18n_module_pt.properties
@@ -2180,6 +2180,6 @@ stage_save_hint_text=An updated program stage is not saved until the program its
 stage_add=Add stage
 stage_update=Update stage
 invalid_coordinate=Invalid coordinate
-output_combo=Output category combo
+output_combo=Output category option combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options

--- a/src/i18n/i18n_module_pt_BR.properties
+++ b/src/i18n/i18n_module_pt_BR.properties
@@ -2180,6 +2180,6 @@ stage_save_hint_text=An updated program stage is not saved until the program its
 stage_add=Add stage
 stage_update=Update stage
 invalid_coordinate=Invalid coordinate
-output_combo=Output category combo
+output_combo=Output category option combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options

--- a/src/i18n/i18n_module_ru.properties
+++ b/src/i18n/i18n_module_ru.properties
@@ -2180,6 +2180,6 @@ stage_save_hint_text=An updated program stage is not saved until the program its
 stage_add=Add stage
 stage_update=Update stage
 invalid_coordinate=Invalid coordinate
-output_combo=Output category combo
+output_combo=Output category option combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options

--- a/src/i18n/i18n_module_tg.properties
+++ b/src/i18n/i18n_module_tg.properties
@@ -2180,6 +2180,6 @@ stage_save_hint_text=An updated program stage is not saved until the program its
 stage_add=Add stage
 stage_update=Update stage
 invalid_coordinate=Invalid coordinate
-output_combo=Output category combo
+output_combo=Output category option combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options

--- a/src/i18n/i18n_module_ur.properties
+++ b/src/i18n/i18n_module_ur.properties
@@ -2180,6 +2180,6 @@ stage_save_hint_text=An updated program stage is not saved until the program its
 stage_add=Add stage
 stage_update=Update stage
 invalid_coordinate=Invalid coordinate
-output_combo=Output category combo
+output_combo=Output category option combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options

--- a/src/i18n/i18n_module_vi.properties
+++ b/src/i18n/i18n_module_vi.properties
@@ -2180,6 +2180,6 @@ stage_save_hint_text=An updated program stage is not saved until the program its
 stage_add=Add stage
 stage_update=Update stage
 invalid_coordinate=Invalid coordinate
-output_combo=Output category combo
+output_combo=Output category option combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options

--- a/src/i18n/i18n_module_zh.properties
+++ b/src/i18n/i18n_module_zh.properties
@@ -2180,6 +2180,6 @@ stage_save_hint_text=An updated program stage is not saved until the program its
 stage_add=Add stage
 stage_update=Update stage
 invalid_coordinate=Invalid coordinate
-output_combo=Output category combo
+output_combo=Output category option combo
 output_combo_loading=Loading category combo options...
 output_combo_error=Could not load category combo options


### PR DESCRIPTION
V30
Some label text was incorrect and for reasons unknown to me, that had to be corrected in 15 places...
Note: I have only fixed this for v32, v31 and v30. V33 and v34 already had the correct string in place...