### PR TITLE
fix: add auto-scroll-body-content to all dialog instances (v31)

### DIFF
--- a/src/EditModel/event-program/create-data-entry-form/AddOrEditSection.component.js
+++ b/src/EditModel/event-program/create-data-entry-form/AddOrEditSection.component.js
@@ -162,6 +162,7 @@ class AddOrEditSection extends Component {
                     actions={actions}
                     open={this.state.dialogOpen}
                     onRequestClose={this.closeDialog}
+                    autoScrollBodyContent
                 >
                     <TextField
                         ref={this.focusOnSectionName}

--- a/src/EditModel/event-program/create-data-entry-form/Section.component.js
+++ b/src/EditModel/event-program/create-data-entry-form/Section.component.js
@@ -162,6 +162,7 @@ class Section extends Component {
                     actions={removalDialogActions}
                     open={this.state.showRemovalDialog}
                     onRequestClose={this.closeRemovalDialog}
+                    autoScrollBodyContent
                 >
                     <Heading level={2}>{this.props.section.displayName}</Heading>
                 </Dialog>

--- a/src/EditModel/event-program/notifications/NotificationDeleteDialog.js
+++ b/src/EditModel/event-program/notifications/NotificationDeleteDialog.js
@@ -27,6 +27,7 @@ const DeleteDialog = ({ onCancel, onConfirm, question, open, t }) => {
             modal={false}
             open={open}
             onRequestClose={onCancel}
+            autoScrollBodyContent
         >
             {question}
         </Dialog>

--- a/src/List/predictor-dialog/PredictorDialog.component.js
+++ b/src/List/predictor-dialog/PredictorDialog.component.js
@@ -92,6 +92,7 @@ class PredictorDialog extends React.Component {
                 title={this.getTranslation('run_predictor')}
                 contentStyle={{ maxWidth: 450 }}
                 bodyStyle={{ marginLeft: 64 }}
+                autoScrollBodyContent
             >
                 {this.state.running ? (
                     <div>

--- a/src/config/field-overrides/predictor/ExpressionDialog.js
+++ b/src/config/field-overrides/predictor/ExpressionDialog.js
@@ -35,6 +35,7 @@ export default function ExpressionDialog({ open, handleClose, handleSaveAndClose
             contentStyle={customContentStyle}
             style={{ padding: '1rem' }}
             onRequestClose={handleClose}
+            autoScrollBodyContent
         >
             {showMissingValueStrategy && (
                 <MissingValueStrategy

--- a/src/forms/form-fields/helpers/IconPickerDialog/IconPickerDialog.js
+++ b/src/forms/form-fields/helpers/IconPickerDialog/IconPickerDialog.js
@@ -207,6 +207,7 @@ export default class IconPickerDialog extends Component {
                     titleClassName="icon-picker__title"
                     bodyClassName="icon-picker__body"
                     actionsContainerClassName="icon-picker__actions"
+                    autoScrollBodyContent
                 >
                     <div className="icon-picker__filter-bar">
                         {this.renderTypeFilter()}


### PR DESCRIPTION
Note: this backport only contains changes to 6 files, not 7 as in the other PRs. This is because the `DownloadObjectDialog` was introduced after v31.