### PR TITLE
fix: add auto-scroll-body-content to all dialog instances (v34)

### DIFF
--- a/src/EditModel/event-program/create-data-entry-form/AddOrEditSection.component.js
+++ b/src/EditModel/event-program/create-data-entry-form/AddOrEditSection.component.js
@@ -162,6 +162,7 @@ class AddOrEditSection extends Component {
                     actions={actions}
                     open={this.state.dialogOpen}
                     onRequestClose={this.closeDialog}
+                    autoScrollBodyContent
                 >
                     <TextField
                         ref={this.focusOnSectionName}

--- a/src/EditModel/event-program/create-data-entry-form/Section.component.js
+++ b/src/EditModel/event-program/create-data-entry-form/Section.component.js
@@ -163,6 +163,7 @@ class Section extends Component {
                     actions={removalDialogActions}
                     open={this.state.showRemovalDialog}
                     onRequestClose={this.closeRemovalDialog}
+                    autoScrollBodyContent
                 >
                     <Heading level={2}>{this.props.section.displayName}</Heading>
                 </Dialog>

--- a/src/EditModel/event-program/notifications/NotificationDeleteDialog.js
+++ b/src/EditModel/event-program/notifications/NotificationDeleteDialog.js
@@ -27,6 +27,7 @@ const DeleteDialog = ({ onCancel, onConfirm, question, open, t }) => {
             modal={false}
             open={open}
             onRequestClose={onCancel}
+            autoScrollBodyContent
         >
             {question}
         </Dialog>

--- a/src/List/DownloadObjectDialog.js
+++ b/src/List/DownloadObjectDialog.js
@@ -154,6 +154,7 @@ export default class DownloadObjectDialog extends Component {
                 title={this.t('download_metadata')}
                 onRequestClose={this.props.defaultCloseDialog}
                 contentStyle={styles.dialog}
+                autoScrollBodyContent
             >
                 {this.renderDownloadCount()}
                 {this.renderForm()}

--- a/src/List/predictor-dialog/PredictorDialog.component.js
+++ b/src/List/predictor-dialog/PredictorDialog.component.js
@@ -92,6 +92,7 @@ class PredictorDialog extends React.Component {
                 title={this.getTranslation('run_predictor')}
                 contentStyle={{ maxWidth: 450 }}
                 bodyStyle={{ marginLeft: 64 }}
+                autoScrollBodyContent
             >
                 {this.state.running ? (
                     <div>

--- a/src/config/field-overrides/predictor/ExpressionDialog.js
+++ b/src/config/field-overrides/predictor/ExpressionDialog.js
@@ -36,6 +36,7 @@ export default function ExpressionDialog({ open, handleClose, handleSaveAndClose
             contentStyle={customContentStyle}
             style={{ padding: '1rem' }}
             onRequestClose={handleClose}
+            autoScrollBodyContent
         >
             {showMissingValueStrategy && (
                 <MissingValueStrategy

--- a/src/forms/form-fields/helpers/IconPickerDialog/IconPickerDialog.js
+++ b/src/forms/form-fields/helpers/IconPickerDialog/IconPickerDialog.js
@@ -256,6 +256,7 @@ export default class IconPickerDialog extends Component {
                     titleClassName="icon-picker__title"
                     bodyClassName="icon-picker__body"
                     actionsContainerClassName="icon-picker__actions"
+                    autoScrollBodyContent
                 >
                     <div className="icon-picker__filter-bar">
                         {this.renderTypeFilter()}


### PR DESCRIPTION
When you are reviewing this PR, could you also confirm that the base branch is correct? I am assuming, since we are in the soft-freeze period (AKA get last bug-fixes into v34), that I can still just use the plain v34 branch and not some v34.#.# branch.