### PR TITLE
fix(program-rulee-action): remove date-to-send-message field

### DIFF
--- a/src/config/field-overrides/program-rules/programRuleActionTypes.js
+++ b/src/config/field-overrides/program-rules/programRuleActionTypes.js
@@ -124,10 +124,7 @@ const actionTypeFieldMapping = {
     },
     SENDMESSAGE: {
         label: 'send_message',
-        optional: ['templateUid', 'data'],
-        labelOverrides: {
-            data: 'date_to_send_message'
-        }
+        optional: ['templateUid'],
     },
     SCHEDULEMESSAGE: {
         label: 'schedule_message',


### PR DESCRIPTION
After editing the SENDMESSAGE config, the dialog now looks like below:
![Screenshot 2020-03-23 at 09 46 49](https://user-images.githubusercontent.com/353236/77298751-af287500-6ceb-11ea-89d7-76967a60313d.png)
