### PR TITLE
fix(program-rule-action): remove date-to-send-message field (v34.0)

### DIFF
--- a/src/config/field-overrides/program-rules/programRuleActionTypes.js
+++ b/src/config/field-overrides/program-rules/programRuleActionTypes.js
@@ -124,10 +124,7 @@ const actionTypeFieldMapping = {
     },
     SENDMESSAGE: {
         label: 'send_message',
-        optional: ['templateUid', 'data'],
-        labelOverrides: {
-            data: 'date_to_send_message'
-        }
+        optional: ['templateUid'],
     },
     SCHEDULEMESSAGE: {
         label: 'schedule_message',


### PR DESCRIPTION
This one is against the `patch/2.34.0` branch, so it is included in the release.