### PR TITLE
feat(dataset): add "open periods after co end date"-field

### DIFF
--- a/src/EditModel/form-rules/index.js
+++ b/src/EditModel/form-rules/index.js
@@ -18,6 +18,7 @@ const whenOperatorMap = new Map([
     ['SYSTEM_SETTING_IS_FALSE', systemSettingIsFalseOperator],
     ['IS_VALID_POINT', isPointOperator],
     ['IS_HIDDEN_FIELD', isHiddenFieldOperator],
+    ['PREDICATE', predicateOperator]
 ]);
 
 const operationsMap = new Map([
@@ -109,6 +110,10 @@ function oneOfOperator(value, list) {
 
 function noneOfOperator(value, list) {
     return list.indexOf(value) < 0;
+}
+
+function predicateOperator(value, predicate) {
+    return predicate(value)
 }
 
 function isPointOperator(value) {

--- a/src/config/field-config/field-order.js
+++ b/src/config/field-config/field-order.js
@@ -115,6 +115,7 @@ const fieldOrderByName = new Map([
         'periodType',
         'dataInputPeriods',
         'categoryCombo',
+        'openPeriodsAfterCoEndDate',
         'notificationRecipients',
         'notifyCompletingUser',
         'workflow',

--- a/src/config/field-rules.js
+++ b/src/config/field-rules.js
@@ -796,4 +796,17 @@ export default new Map([
             }],
         },
     ]],
+    ['dataSet', [
+        {
+            field: 'openPeriodsAfterCoEndDate',
+            when: {
+                field: 'categoryCombo',
+                operator: 'PREDICATE',
+                value: (categoryComboField) => categoryComboField && categoryComboField.name === 'default'
+            },
+            operations: [{
+                type: 'HIDE_FIELD',
+            }]
+        }
+    ]]
 ]);

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -2251,3 +2251,4 @@ no_attributes=No attributes selected
 no_data_elements=No data elements selected
 create_registration_form=Create registration form
 next_schedule_date=Default next scheduled date
+open_periods_after_co_end_date=Open periods after category option end date


### PR DESCRIPTION
Needed to add a new operator (predicate) to the field-runner engine, as the value for `categoryCombo` is a model, and there's currently no way to check for equality here. In my opinion the `predicate` is also a good addition, and should probably have been used instead of custom made "operator types". It's a very simple rule that gets the value of the field and calls the `value` of the when-Rule, so that needs to be a function. 


See https://jira.dhis2.org/browse/DHIS2-9080 and https://jira.dhis2.org/browse/DHIS2-9081 for more information regarding the "open periods after co end date"-field.