### PR TITLE
fix(catcombo-select): use option-model instead of id-object if default

### DIFF
--- a/src/forms/form-fields/drop-down-async.js
+++ b/src/forms/form-fields/drop-down-async.js
@@ -176,7 +176,7 @@ class DropDownAsync extends Component {
                             }
 
                             if (defaultOption) {
-                                this.props.onChange({ target: { value: { id: defaultOption.value } } })
+                                this.props.onChange({ target: { value: defaultOption.model } })
                             }
                         }
                     },


### PR DESCRIPTION
This touches on a very hacky part of the app - the catCombo selection. 
More precisely the newest "hacky"-part, that select 'None' as the default catCombo. This only selected the id of the object the default-object. This has been fine before, but we need the `name` of the option (which is always `default`). One solution would to just be hardcoding this, but I figured it should be the same as when you select a Cat-Combo normally (result in a d2-model).