### PR TITLE
fix(programrule): fix validation

### DIFF
--- a/src/config/field-overrides/program-indicator/ExpressionStatusIcon.js
+++ b/src/config/field-overrides/program-indicator/ExpressionStatusIcon.js
@@ -68,6 +68,9 @@ export function getBackgroundColorForExpressionStatus(status) {
 export default ExpressionStatusIcon;
 
 export function ExpressionDescription({ status }) {
+    if(!status) {
+        return null
+    }
 
     return (
         <div style={styles.status.container(status.status)}>

--- a/src/config/field-overrides/program-indicator/ExpressionStatusIcon.js
+++ b/src/config/field-overrides/program-indicator/ExpressionStatusIcon.js
@@ -16,6 +16,7 @@ const styles = {
     status: {
         container: status => ({
             display: 'flex',
+            flexWrap: 'wrap',
             flexDirection: 'row',
             padding: '2rem',
             border: `1px solid ${getColorForExpressionStatus(status)}`,
@@ -27,6 +28,18 @@ const styles = {
     statusMessage: {
         padding: '.25rem',
         paddingLeft: '1rem',
+        flexBasis: '90%',
+    },
+    statusDetail: {
+        overflow: 'auto',
+        maxHeight: '180px',
+        wordWrap: 'break-word',
+        display: 'block',
+        border: '1px solid rgb(0,0,0,0.4)',
+        padding: '8px',
+        backgroundColor: '#e8e8e8',
+        whiteSpace: 'pre-wrap',
+        opacity: 0.8,
     },
 };
 
@@ -72,11 +85,12 @@ export function ExpressionDescription({ status }) {
         return null
     }
 
-    return (
-        <div style={styles.status.container(status.status)}>
+    return <div style={styles.status.container(status.status)}>
             <ExpressionStatusIcon status={status.status} />
-            <span style={styles.statusMessage}>
-                {status.message}
-            </span>
-        </div>)
+            <span style={styles.statusMessage}>{status.message}</span>
+            {status.status === ExpressionStatus.INVALID && status.details && <pre style={styles.statusDetail}
+                    >
+                        {status.details}
+                    </pre>}
+        </div>;
 }

--- a/src/config/field-overrides/program-indicator/createExpressionValidator.js
+++ b/src/config/field-overrides/program-indicator/createExpressionValidator.js
@@ -31,6 +31,7 @@ export default function createExpressionValidator(path) {
                         .then(({ status, description, message }) => ({
                             status: status === 'OK' ? ExpressionStatus.VALID : ExpressionStatus.INVALID,
                             message: status === 'OK' ? description : message,
+                            details: description
                         }))
                         .catch((error) => {
                             // If error contains a message and an error status we consider it to be a valid response

--- a/src/config/field-overrides/programRule.js
+++ b/src/config/field-overrides/programRule.js
@@ -15,33 +15,50 @@ import { ExpressionStatus } from './program-indicator/ExpressionStatusIcon';
 import { AnalyticsPeriodBoundaries } from './program-indicator/AnalyticsPeriodBoundaries';
 import createExpressionValidator from './program-indicator/createExpressionValidator';
 
+const setValidatorSubscription = (context, subFunc, programId) => {
+    const path = `programRules/condition/description?programId=${
+        programId
+    }`;
+    const { status$, validate } = createExpressionValidator(path, subFunc);
+    context.validatorStatusSubscription = status$.subscribe(subFunc)
+    context.validate = validate
+    context.props.setValidatorProgramId(programId)
+    return { status$, validate }
+};
+
 const enhance = compose(
     getContext({ d2: PropTypes.object }),
     withState('status', 'setStatus', ({ d2 }) => ({
         status: ExpressionStatus.PENDING,
         message: d2.i18n.getTranslation('checking_expression_status'),
     })),
+    withState('validatorProgramId', 'setValidatorProgramId', () => undefined),
     lifecycle({
         componentDidMount() {
             const { setStatus, value } = this.props;
-            const path = `programRules/condition/description?programRule=${this.props.model.id}`
-            const { status$, validate } = createExpressionValidator(path, setStatus);
-
-            this.validate = validate;
-
-            this.validatorStatusSubscription = status$.subscribe(setStatus);
-
+            if(!this.props.model || !this.props.model.program || !this.props.model.program.id) {
+                // this only happens when a new rule is created
+                setStatus(null) // prevent status from being shown when program is not selected
+                return
+            }
+            setValidatorSubscription(this, setStatus, this.props.model.program.id)
             this.validate(value);
         },
 
         componentWillReceiveProps(newProps) {
-            if (newProps.value !== this.props.value) {
+            // Need to create a new validator when program is changed, as the validation depends on it
+            if (newProps.model.program && (!this.props.validatorProgramId || newProps.model.program.id !== this.props.validatorProgramId)) {
+                this.validatorStatusSubscription && this.validatorStatusSubscription.unsubscribe();
+                setValidatorSubscription(this, this.props.setStatus, newProps.model.program.id);
+                this.validate(newProps.value);
+            }
+            else if (newProps.value !== this.props.value) {
                 this.validate(newProps.value);
             }
         },
 
         componentWillUnmount() {
-            this.validatorStatusSubscription.unsubscribe();
+            this.validatorStatusSubscription && this.validatorStatusSubscription.unsubscribe();
         },
     }),
 );


### PR DESCRIPTION

Previously it was required to have the id of the programRule for validation. This made it impossible to validate new program rules, as the ids obviously do not exist before creation. The id is used to get the programRuleVariables, which is now changed to use the programId instead. Thanks @zubaira for the quick fix!

