### PR TITLE
fix(program-stage-section): fix pss displayName

### DIFF
--- a/src/EditModel/epicHelpers.js
+++ b/src/EditModel/epicHelpers.js
@@ -111,7 +111,7 @@ export function createModelToEditProgramStageEpic(actionType, store, storeProp) 
                     to the server, and upon reloading the model, the server-defined displayName will be shown */
 
                     if (field === 'name') {
-                        updateRegularValue(model, 'displayName', value);
+                        model.dataValues.displayName = value
                     }
                 }
                 // Write back the state to the store

--- a/src/EditModel/event-program/create-data-entry-form/epics.js
+++ b/src/EditModel/event-program/create-data-entry-form/epics.js
@@ -51,7 +51,9 @@ const updateProgramStageSection = store => action$ => action$
                     // Modify the original Model instance
                     if (isEqual(section.id, programStageSectionId)) {
                         section.name = newProgramStageSectionData.name;
-                        section.displayName = newProgramStageSectionData.name;
+                        // this is just used to show edited name immediately, not sent to serv
+                        // cannot change dispayName directly as it does not have a setter (writable: false)
+                        section.dataValues.displayName = newProgramStageSectionData.name;
                         section.description = newProgramStageSectionData.description;
                         section.renderType = newProgramStageSectionData.renderType;
                     }
@@ -103,14 +105,11 @@ const addProgramStageSection = store => action$ => action$
             const sortOrder = getOr(-1, 'sortOrder', maxBy(section => get('sortOrder', section), programStageSections)) + 1;
 
             // Create new section model and set the properties we can
-            const newSection = d2.models.programStageSection.create({ id: generateUid(), dataElements: [] });
+            const newSection = d2.models.programStageSection.create({ id: generateUid(), dataElements: [], displayName: newSectionData.name });
             newSection.name = newSectionData.name;
-            newSection.displayName = newSectionData.name;
             newSection.description = newSectionData.description;
             newSection.renderType = newSectionData.renderType;
             newSection.sortOrder = sortOrder;
-
-            console.log(newSection);
 
             // Add the section to the programStage, otherwise the section won't be associated with the programStage
             newSection.programStage = programStage;


### PR DESCRIPTION
The schema for `displayName` has changed to `writable: false`, which means that the d2-model will not add a setter for that property. That means a JS error was thrown when trying to edit that prop. DisplayName is readonly, but we are using it when for the title before it's sent to the server, so we need to have one at creation time and when editing. 
Turns out that we can just send the displayName to `d2.model.create` directly. 

Needed a small hack to update the displayName through `dataValues`, to update the name when its edited.