### PR TITLE
fix(programrule): show error

### DIFF
--- a/src/EditModel/EditModelForm.component.js
+++ b/src/EditModel/EditModelForm.component.js
@@ -202,7 +202,12 @@ export default React.createClass({
 
             this.props.onSaveSuccess(this.state.modelToEdit);
         } else {
-            const firstErrorMessage = extractFirstErrorMessageFromServer(error);
+            let firstErrorMessage
+            if(typeof error === 'string') {
+                firstErrorMessage = error
+            } else {
+                firstErrorMessage = extractFirstErrorMessageFromServer(error);
+            }
             snackActions.show({ message: firstErrorMessage, action: 'ok' });
             this.props.onSaveError && this.props.onSaveError(error);
             log.error(error);


### PR DESCRIPTION
In some cases the error string may have already been extracted in the `objectAction`, this causes the resulting `firstErrorMessage` to be `undefined`, and thus just show an empty snackbar. 