### PR TITLE
feat(icon-field): fallback to dhis2-logo if selected icon does not exist

### DIFF
--- a/src/forms/form-fields/helpers/IconPickerDialog/IconPickerDialog.js
+++ b/src/forms/form-fields/helpers/IconPickerDialog/IconPickerDialog.js
@@ -102,12 +102,18 @@ export default class IconPickerDialog extends Component {
     renderIconButtonImage = (iconKey) => {
         const contextPath = this.context.d2.system.systemInfo.contextPath;
         const altText = this.context.d2.i18n.getTranslation('current_icon');
+        const fallbackIconPath = `${contextPath}/api/icons/dhis2_logo_outline/icon.svg`
         return (
             <img
                 src={`${contextPath}/api/icons/${iconKey}/icon.svg`}
                 alt={altText}
                 className="icon-picker__icon-button-image"
                 style={{ backgroundColor: 'white', overflow: 'hidden' }}
+                onError={({ target }) => {
+                    target.onerror = "";
+                    target.src=fallbackIconPath;
+                    return true;
+                }}
             />
         );
     };


### PR DESCRIPTION
See https://jira.dhis2.org/browse/DHIS2-10095

There's going to be a cleanup of icons on the backend so that will probably make some selected icons fail. 
Need to double-check that the current fallback is correct.