### PR TITLE
fix: hierarchy operations paging

### DIFF
--- a/src/OrganisationUnitHierarchy/OrganisationUnitHierarchy.component.js
+++ b/src/OrganisationUnitHierarchy/OrganisationUnitHierarchy.component.js
@@ -105,17 +105,31 @@ function onClickLeft(event, model) {
         .take(1) // Only grab the current state
         .subscribe(
             (hierarchy) => {
-                let selectedLeft = [];
-                const indexOfModelInSelected = hierarchy.selectedLeft
-                    .map(model => model.id)
-                    .indexOf(model.id);
+                const selectAllChildren = event.shiftKey
 
-                if (indexOfModelInSelected >= 0) {
-                    selectedLeft = hierarchy.selectedLeft
-                       .slice(0, indexOfModelInSelected)
-                       .concat(hierarchy.selectedLeft.slice(indexOfModelInSelected + 1));
+                let selectedLeft = [];
+
+                let modelIdsToRemove = hierarchy.selectedLeft
+                    .filter(m => m.id === model.id).map(m => m.id)
+
+                const children = model.children.toArray()
+                let childrenToAdd = []
+
+                // add all children that is not already selected if shift-clicked
+                if(selectAllChildren) {
+                    childrenToAdd = children.filter(
+                        (child) => hierarchy.selectedLeft.findIndex((m) => m.id === child.id) < 0
+                    );
+                }
+
+                // remove selection if already present
+                if (modelIdsToRemove.length > 0) {
+                    if(selectAllChildren) {
+                        modelIdsToRemove.push(...children.map(child => child.id))
+                    }
+                    selectedLeft = hierarchy.selectedLeft.filter(m => modelIdsToRemove.indexOf(m.id) < 0)
                 } else {
-                    selectedLeft = hierarchy.selectedLeft.concat([model]);
+                    selectedLeft = hierarchy.selectedLeft.concat(model, ...childrenToAdd);
                 }
 
                 setAppState({

--- a/src/OrganisationUnitHierarchy/OrganisationUnitHierarchy.component.js
+++ b/src/OrganisationUnitHierarchy/OrganisationUnitHierarchy.component.js
@@ -133,7 +133,7 @@ async function getOrganisationUnitByIds(ids) {
     const d2 = await getInstance();
 
     const organisationUnits = await d2.models.organisationUnit
-        .list({ filter: [`id:in:[${ids.join(',')}]`], fields: ':owner,href,id,parent,displayName,path,children[id,displayName,path]' });
+        .list({ filter: [`id:in:[${ids.join(',')}]`], fields: ':owner,href,id,parent,displayName,path,children[id,displayName,path]', paging: false });
 
     return organisationUnits.toArray();
 }


### PR DESCRIPTION
See https://jira.dhis2.org/browse/DHIS2-9860

Also added a small feature to make it easier to test this - shift clicking a parent will add all children. Note that this will only work when the parent is expanded.
