### PR TITLE
fix(programs): use correct rendering type for attributes with optionSet

### DIFF
--- a/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/AssignAttributes.js
+++ b/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/AssignAttributes.js
@@ -157,7 +157,8 @@ function addDisplayProperties(attributes, renderingOptions) {
         const { displayName, valueType, optionSet, unique } = attributes.find(
             ({ id }) => id === trackedEntityAttribute.id
         );
-        const renderTypeOptions = getRenderTypeOptions(assignedAttribute, TRACKED_ENTITY_ATTRIBUTE_CLAZZ, renderingOptions);
+        
+        const renderTypeOptions = getRenderTypeOptions(trackedEntityAttribute, TRACKED_ENTITY_ATTRIBUTE_CLAZZ, renderingOptions);
         return {
             ...other,
             trackedEntityAttribute: {


### PR DESCRIPTION
`getRenderTypeOptions`-function looks for `optionSet` to determine the correct redering options. However the `programTrackedEntityAttribute` was passed, which does not include the optionSet-property, this property is at the `trackedEntityAttribute`. 

https://jira.dhis2.org/browse/DHIS2-10184