### PR TITLE
feat(list): get translatable properties from schema for all objects

### DIFF
--- a/src/List/List.component.js
+++ b/src/List/List.component.js
@@ -101,28 +101,16 @@ function actionsThatRequireDelete(action) {
     return false;
 }
 
-export function getTranslatablePropertiesForModelType(modelType) {
-    const fieldsForModel = fieldOrder.for(modelType);
+export function getTranslatablePropertiesForModelType(modelType, model) {
+    const fieldsForModel = new Set(fieldOrder.for(modelType));
     const defaultTranslatableProperties = ['name', 'shortName'];
 
-    if (fieldsForModel.indexOf('description') >= 0) {
-        defaultTranslatableProperties.push('description');
+    if(!model) {
+        return defaultTranslatableProperties
     }
-
-    switch (modelType) {
-    case 'dataElement':
-        return defaultTranslatableProperties.concat(['formName']);
-    case 'organisationUnitLevel':
-        return ['name'];
-    case 'program':
-        return defaultTranslatableProperties.concat(['description'])
-    case 'relationshipType':
-        return defaultTranslatableProperties.concat(['fromToName', 'toFromName'])
-    default:
-        break;
-    }
-
-    return defaultTranslatableProperties;
+    return model.modelDefinition
+        .getTranslatableProperties()
+        .filter(prop => fieldsForModel.has(prop)); // ensure translationkey is in model-form
 }
 
 const modelsThatMapToOtherDisplayName = {
@@ -638,7 +626,7 @@ class List extends Component {
                         onTranslationSaved={this.translationSaved}
                         onTranslationError={this.translationError}
                         onRequestClose={this.closeTranslationDialog}
-                        fieldsToTranslate={getTranslatablePropertiesForModelType(this.props.params.modelType)}
+                        fieldsToTranslate={getTranslatablePropertiesForModelType(this.props.params.modelType, this.state.translation.model)}
                     />}
                 <CompulsoryDataElementOperandDialog
                     model={this.state.dataElementOperand.model}


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-8897


Note that fields not defined in the 'field-order' for the model is not included. This is to prevent some models from showing fields to be translated that are not editable from the UI. In most cases the `field-order` for that model is a superset of translatable-keys, but sometimes a key might not have been added yet - so this prevents some weird discrepancies. 