### PR TITLE
fix(programs): request publicAccess explicitly

### DIFF
--- a/src/EditModel/event-program/epics.js
+++ b/src/EditModel/event-program/epics.js
@@ -148,6 +148,9 @@ function loadEventProgramMetadataByProgramId(programPayload) {
         'notificationTemplates[:owner]',
         'programTrackedEntityAttributes',
         'user[id,name]',
+        'publicAccess',
+        'userGroupAccesses',
+        'userAccesses'
     ].join(',');
 
     // Tomcat 8.5 does not allow unencoded brackets in querystrings. By passing the query params
@@ -155,7 +158,7 @@ function loadEventProgramMetadataByProgramId(programPayload) {
     const queryParams = {
         fields: ':owner,displayName',
         'programs:filter': `id:eq:${programId}`,
-        'programs:fields': `${programFields},programStages[:owner,user[id,name],displayName,attributeValues[:all,attribute[id,name,displayName]],programStageDataElements[:owner,renderType,dataElement[id,displayName,valueType,optionSet,domainType]],notificationTemplates[:owner,displayName],dataEntryForm[:owner],programStageSections[:owner,displayName,dataElements[id,displayName]]]`,
+        'programs:fields': `${programFields},programStages[:owner, publicAccess, userGroupAccesses, userAccesses, user[id,name],displayName,attributeValues[:all,attribute[id,name,displayName]],programStageDataElements[:owner,renderType,dataElement[id,displayName,valueType,optionSet,domainType]],notificationTemplates[:owner,displayName],dataEntryForm[:owner],programStageSections[:owner,displayName,dataElements[id,displayName]]]`,
         'dataElements:fields': 'id,displayName,valueType,optionSet',
         'dataElements:filter': 'domainType:eq:TRACKER',
         'trackedEntityAttributes:fields': 'id,displayName,valueType,optionSet,unique'


### PR DESCRIPTION
Fixes the `Access`-stage in programs. `publicAccess` is not returned when requested by `:owner` anymore, so the sharing-component was not shown at all due to missing information. 

See https://jira.dhis2.org/browse/DHIS2-10464 


