### PR TITLE
fix(sqlView): format non-primitive values

### DIFF
--- a/src/SqlView/SqlView.component.js
+++ b/src/SqlView/SqlView.component.js
@@ -138,8 +138,8 @@ class SqlView extends Component {
 
     /* eslint-disable react/no-array-index-key */
     renderCell = (cell, index) => {
-        const formattedValue =
-            Object(cell) !== cell ? cell : JSON.stringify(cell, null, 2);
+        const isObject = typeof cell === 'object' && cell != null;
+        const formattedValue = isObject ? JSON.stringify(cell, null, 2) : cell;
 
         return <td key={`cell${index}`}>{formattedValue}</td>;
     };

--- a/src/SqlView/SqlView.component.js
+++ b/src/SqlView/SqlView.component.js
@@ -46,6 +46,7 @@ class SqlView extends Component {
             const { listGrid } = await d2.Api.getApi().get(url, queryParams);
             this.setState({ listGrid });
         } catch (error) {
+            console.error(error)
             backToList();
             snackActions.show({ message: d2.i18n.getTranslation('sql_query_error'), action: 'ok' });
         }
@@ -136,8 +137,16 @@ class SqlView extends Component {
     }
 
     /* eslint-disable react/no-array-index-key */
-    renderCell = (cell, index) => <td key={`cell${index}`}>{cell}</td>;
-    renderRow = (row, index) => <tr key={`row${index}`}>{row.map(this.renderCell)}</tr>;
+    renderCell = (cell, index) => {
+        const formattedValue =
+            Object(cell) !== cell ? cell : JSON.stringify(cell, null, 2);
+
+        return <td key={`cell${index}`}>{formattedValue}</td>;
+    };
+
+    renderRow = (row, index) => (
+        <tr key={`row${index}`}>{row.map(this.renderCell)}</tr>
+    );
     /* eslint-enable react/no-array-index-key */
 
     renderTable() {


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-10354

SQL-views that had cells with objects in them (eg. `Data elements` in Demo-DB) would crash the SQL-view component as React does not allow for rendering objects. I've added a simple formatter that checks for non-primitive values that will be stringified. 

Another strange this I encountered was that the `catch` in `componentDidMount` caught the error in the `render`-method that caused this. We should try to log errors when they are caught unless we know exactly what the error is.