### PR TITLE
fix: registration form displayName

### DIFF
--- a/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/data-entry-form/epics.js
+++ b/src/EditModel/event-program/tracker-program/assign-tracked-entity-attributes/data-entry-form/epics.js
@@ -76,7 +76,9 @@ const addProgramSection = store => action$ => action$
             // Create new section model and set the properties we can
             const newSection = d2.models.programSection.create({ id: generateUid() });
             newSection.name = newSectionData.name;
-            newSection.displayName = newSectionData.name;
+            // this is just used to show edited name immediately, not sent to serv
+            // cannot change dispayName directly as it does not have a setter (writable: false)
+            newSection.dataValues.displayName = newSectionData.name;
             newSection.description = newSectionData.description;
             newSection.renderType = newSectionData.renderType;
             newSection.sortOrder = sortOrder;


### PR DESCRIPTION
This is the same fix as in https://github.com/dhis2/maintenance-app/pull/1421 . Forgot/ did not identify the issue to apply it to registration form.

Related: https://jira.dhis2.org/browse/DHIS2-9969