### PR TITLE
fix(expressionmanager): show .periodOffset for indicators only

### DIFF
--- a/src/EditModel/IndicatorExpressionManagerContainer.component.js
+++ b/src/EditModel/IndicatorExpressionManagerContainer.component.js
@@ -77,6 +77,7 @@ const IndicatorExpressionManagerContainer = React.createClass({
                 titleText={this.props.titleText}
                 validateExpression={actionToValidation$}
                 ref="expressionManager"
+                expressionType='indicator'
             />
         );
     },

--- a/src/EditModel/expression/ExpressionFunctions.js
+++ b/src/EditModel/expression/ExpressionFunctions.js
@@ -29,6 +29,7 @@ class ExpressionFunctions extends Component {
     renderButton(value, label) {
         return (
             <FlatButton
+                key={value} 
                 style={styles.button}
                 onClick={this.createFunctionClick(value)}
             >

--- a/src/EditModel/expression/ExpressionFunctions.js
+++ b/src/EditModel/expression/ExpressionFunctions.js
@@ -15,6 +15,10 @@ const styles = {
     },
 };
 
+const functionsForExpressionType = {
+    indicator: [' .periodOffset( ']
+}
+
 class ExpressionFunctions extends Component {
     createFunctionClick(operatorValue) {
         return function functionButtonClicked() {
@@ -34,7 +38,9 @@ class ExpressionFunctions extends Component {
     }
 
     render() {
+        const expressionType = this.props.expressionType
         const classList = classes('expression-functions');
+        const extraFunctionsForType = expressionType ? functionsForExpressionType[expressionType] : []
 
         return (
             <div className={classList} style={styles.wrapper}>
@@ -46,7 +52,7 @@ class ExpressionFunctions extends Component {
                 {this.renderButton(' least( ')}
                 {this.renderButton(' log( ')}
                 {this.renderButton(' log10( ')}
-                {this.renderButton(' .periodOffset( ')}
+                {extraFunctionsForType.map(funcName => this.renderButton(funcName))}
             </div>
         );
     }

--- a/src/EditModel/expression/ExpressionManager.js
+++ b/src/EditModel/expression/ExpressionManager.js
@@ -262,6 +262,7 @@ class ExpressionManager extends Component {
                             />
                             <ExpressionFunctions
                                 onFunctionClick={this.appendToFormula}
+                                expressionType={this.props.expressionType}
                             />
                         </Column>
                     </Paper>
@@ -351,6 +352,7 @@ ExpressionManager.propTypes = {
     formulaValue: PropTypes.string,
     titleText: PropTypes.string,
     validateExpression: PropTypes.func,
+    expressionType: PropTypes.oneOf['indicator', 'programIndicator', 'validationRule', 'predictor'],
 };
 
 ExpressionManager.defaultProps = {

--- a/src/EditModel/expression/ExpressionManager.js
+++ b/src/EditModel/expression/ExpressionManager.js
@@ -352,7 +352,7 @@ ExpressionManager.propTypes = {
     formulaValue: PropTypes.string,
     titleText: PropTypes.string,
     validateExpression: PropTypes.func,
-    expressionType: PropTypes.oneOf['indicator', 'programIndicator', 'validationRule', 'predictor'],
+    expressionType: PropTypes.oneOf(['indicator', 'programIndicator', 'validationRule', 'predictor']),
 };
 
 ExpressionManager.defaultProps = {


### PR DESCRIPTION
`.periodOffset` is only valid for indicators. This was added in #1801 

See Jims comment https://jira.dhis2.org/browse/DHIS2-7581