### PR TITLE
chore: upgrade d2

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@dhis2/d2-ui-header-bar": "^1.1.4",
     "@dhis2/d2-ui-sharing-dialog": "^1.0.12",
     "ckeditor": "4.6.1",
-    "d2": "30.0.4",
+    "d2": "30.2.2",
     "d2-ui": "29.0.34",
     "lodash": "^4.17.11",
     "material-design-icons-iconfont": "^4.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2940,10 +2940,10 @@ d2-utilizr@^0.2.15, d2-utilizr@^0.2.9:
     lodash.isset "^4.3.0"
     lodash.isstring "^4.0.1"
 
-d2@30.0.4:
-  version "30.0.4"
-  resolved "https://registry.yarnpkg.com/d2/-/d2-30.0.4.tgz#ba51a43e7daedeb47e01c45aef71649bad1b2159"
-  integrity sha512-GjTfqPq7KAakeN398jnzh0DO7kTofy18UoARJqcASU6RvcVjlJNnRpanHbbaSe05BrjVZx4j05niwDn/VVqJ4w==
+d2@30.2.2:
+  version "30.2.2"
+  resolved "https://registry.yarnpkg.com/d2/-/d2-30.2.2.tgz#4f42fa0d9add9e198eb3f7e2d668bdc817aab7b3"
+  integrity sha512-pLSYvPrfdJYgzAo5IYPVHQ5y1tos6D5+cDvkbJ5wugWzVmuPQjAagm/39FnQ1xhGdAu32YYCRKRkRsTE5mr36A==
   dependencies:
     docdash "^0.4.0"
     jsdoc "^3.5.5"


### PR DESCRIPTION
Related to https://jira.dhis2.org/browse/DHIS2-10464 . Latest d2 adds a patch to treat access-properties (userAccesses and userGroupAccesses) as embedded objects when saved. See https://github.com/dhis2/d2/pull/292 .



