### PR TITLE
fix(stepper): show attributes in steppers

### DIFF
--- a/src/EditModel/EditModelForm.component.js
+++ b/src/EditModel/EditModelForm.component.js
@@ -64,6 +64,7 @@ const modelToEditAndModelForm$ = Observable
 
                 // Check if value is an attribute
                 if (Object.keys(modelToEdit.attributes || []).indexOf(fieldConfig.name) >= 0) {
+                    fieldConfig.isAttribute = true
                     fieldConfig.value = modelToEdit.attributes[fieldConfig.name];
                     return fieldConfig;
                 }

--- a/src/EditModel/stepper/stepper.js
+++ b/src/EditModel/stepper/stepper.js
@@ -31,7 +31,7 @@ export const getStepFields = (step, fieldConfigs, modelType) => {
         fieldConfigs.map(field => {
             if (
                 stepsByField[field.name] === step ||
-                (field.isAttribute && step === 0)
+                (field.isAttribute && step === 0) // add custom attributes-fields to first step
             ) {
                 field.props.style = { display: 'block' };
             } else {

--- a/src/EditModel/stepper/stepper.js
+++ b/src/EditModel/stepper/stepper.js
@@ -28,8 +28,11 @@ function isActiveStep(activeStep, step, index) {
 export const getStepFields = (step, fieldConfigs, modelType) => {
     const stepsByField = fieldGroups.groupsByField(modelType);
     if (stepsByField) {
-        fieldConfigs.map((field) => {
-            if (stepsByField[field.name] === step || field.isAttribute) {
+        fieldConfigs.map(field => {
+            if (
+                stepsByField[field.name] === step ||
+                (field.isAttribute && step === 0)
+            ) {
                 field.props.style = { display: 'block' };
             } else {
                 field.props.style = { display: 'none' };

--- a/src/EditModel/stepper/stepper.js
+++ b/src/EditModel/stepper/stepper.js
@@ -29,7 +29,7 @@ export const getStepFields = (step, fieldConfigs, modelType) => {
     const stepsByField = fieldGroups.groupsByField(modelType);
     if (stepsByField) {
         fieldConfigs.map((field) => {
-            if (stepsByField[field.name] === step) {
+            if (stepsByField[field.name] === step || field.isAttribute) {
                 field.props.style = { display: 'block' };
             } else {
                 field.props.style = { display: 'none' };


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-7230

Adds a `isAttribute`-property to the fieldConfig to easily check if a field is an attribute. Previously the attribute fields were hidden in steppers as all fields not defined in `field-groups.js`-were hidden. 

ProgramIndicators seems to be the only model that is a stepper and supports attributes.

Note that I've hardcoded attributes to show up in the first step. This might not be ideal, but as we are looking to refactor the app, and the first step tends to be the "general" section of a stepper anyway, I think its fine. 
Another solution would be to introduce a special field in the "field-groups"-fields to check for and insert attributes where that special field occurs (eg. something like `__ATTRIBUTES__`). 