### PR TITLE
fix(program-rule-action): fix validation request format

### DIFF
--- a/src/config/field-overrides/program-rules/programRuleActionDialog.component.js
+++ b/src/config/field-overrides/program-rules/programRuleActionDialog.component.js
@@ -355,16 +355,16 @@ class ProgramRuleActionDialog extends React.Component {
         try {
             const { status, description, message } = await api.post(
                 url,
-                `"${expression}"`,
+                expression,
                 requestOptions
             );
-            const isOk = status === 'OK';
 
             const newStatus = {
-                status: isOk
-                    ? ExpressionStatus.VALID
-                    : ExpressionStatus.INVALID,
-                message: isOk ? description : message,
+                status:
+                    status === 'OK'
+                        ? ExpressionStatus.VALID
+                        : ExpressionStatus.INVALID,
+                message,
                 details: description,
             };
 
@@ -373,11 +373,13 @@ class ProgramRuleActionDialog extends React.Component {
                 status: newStatus,
             }));
         } catch (error) {
-            const fallback = this.getTranslation('program_rule_action_fallback_error_message');
-            const message = error.message || fallback;
+            const fallback = this.getTranslation(
+                'program_rule_action_fallback_error_message'
+            );
             const newStatus = {
                 status: ExpressionStatus.INVALID,
-                message,
+                message: error.message || fallback,
+                details: error.description,
             };
 
             this.setState(prevState => ({

--- a/src/config/field-overrides/program-rules/programRuleActionDialog.component.js
+++ b/src/config/field-overrides/program-rules/programRuleActionDialog.component.js
@@ -304,7 +304,17 @@ class ProgramRuleActionDialog extends React.Component {
 
     update(fieldName, value) {
         if (fieldName === 'data') {
-            this.validate(value);
+            if (!value) {
+                /**
+                 * The backend will throw an error when validating without an expression. Since
+                 * it does not make sense to validate something that isn't there, we're omitting
+                 * validation when the expression is absent.
+                 */
+
+                this.setState({ status: null })
+            } else {
+                this.validate(value);
+            }
         }
 
         const ruleAction = this.state.programRuleAction;


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-11665

Zubair and I talked a bit about what could be causing the unexpected validation behaviour. Turns out that this was due to the unnecessary quotes. I had adapted this from another area in the code, and not paid attention to it afterwards. Fixed it, and made some slight tweaks to the way the validation is displayed.

Now validation passes like so:

<img width="509" alt="Screenshot 2021-09-01 at 11 26 30" src="https://user-images.githubusercontent.com/7355199/131651525-3a5b2f2c-4210-4eb0-b736-3ee870cfd269.png">

And fails with a clear error:

<img width="385" alt="Screenshot 2021-09-01 at 11 55 01" src="https://user-images.githubusercontent.com/7355199/131651571-62db624a-1f66-4a94-8308-39a9908d0529.png">

Since the backend throws an error when you try to validate an expression without a POST body, I've skipped validation when there's no expression.