### PR TITLE
fix(program): fix validationStrategy dopdown

### DIFF
--- a/src/config/field-overrides/eventProgramStage.js
+++ b/src/config/field-overrides/eventProgramStage.js
@@ -5,9 +5,6 @@ export default new Map([
         'validationStrategy',
         {
             required: true,
-            fieldOptions: {
-                value: 'ON_UPDATE_AND_INSERT'
-            }
         },
     ],
     [

--- a/src/config/field-rules.js
+++ b/src/config/field-rules.js
@@ -530,7 +530,7 @@ export default new Map([
         },
     ]],
     ['eventProgramStage', [
-        createDefaultRuleForField('validationStrategy', "ON_COMPLETE"),
+        createDefaultRuleForField('validationStrategy', "ON_UPDATE_AND_INSERT"),
     ]],
     ['programIndicator', [{
         field: 'analyticsPeriodBoundaries',


### PR DESCRIPTION
Fix a bug where `validationStrategy` for eventPrograms could not be changed.

This was introduced in https://github.com/dhis2/maintenance-app/pull/665 . The fix did not use the proper way to set the defaultValue, and forced the value to be `On complete`