### PR TITLE
DHIS2-11543_remove_timezone_info_from_dip

### DIFF
--- a/src/config/field-overrides/data-set/DataInputPeriods.component.js
+++ b/src/config/field-overrides/data-set/DataInputPeriods.component.js
@@ -26,6 +26,11 @@ const styles = {
     openDialogButton: { margin: '16px 0' },
 };
 
+const getISOFormatLocalTimestamp = value =>
+    new Date(value.getTime() - value.getTimezoneOffset() * 60000)
+        .toISOString()
+        .substring(0, 23);
+
 class DataInputPeriods extends React.Component {
     constructor(props, context) {
         super(props, context);
@@ -76,7 +81,10 @@ class DataInputPeriods extends React.Component {
         this.setState({
             dataInputPeriods: this.state.dataInputPeriods.map((dip, $i) => {
                 if ($i === $k) {
-                    dip[dateField] = value;
+                    dip[dateField] =
+                        value instanceof Date
+                            ? getISOFormatLocalTimestamp(value)
+                            : value;
                 }
 
                 return dip;


### PR DESCRIPTION
This update is for https://jira.dhis2.org/browse/DHIS2-11543

Currently Material-UI datepicker returns data selected for data input period with local time zone info:

1. I am in Norway (GMT+1), and I select 1 February 2022 as a date
2. Material-UI interprets this as I am selecting 2022-01-31 23:00 UTC ('2022-01-31T23:00:00.000Z')
3. Back end has server time of GMT, and interprets '2022-01-31T23:00:00.000Z' as '2022-01-31T23:00:00.000' local time (according to server). This timestamp without Z is committed to database.
4. When I reopen this the frontend, it receives '2022-01-31T23:00:00.000' from the back end and as this does not have timezone information, it is interpreted as being in local time (that is it is 2022-01-31 23h GMT+1)

This code change removes the timezone information from the selected date. That is if I select 1 February 2022 in GMT+1, it is posted to server as '2022-02-01T00:00:00.000', so that when it is interpreted/committed by the server, it remains '2022-02-01T00:00:00.000'. 

PEPFAR thinks the most sensible approach for the ticket as it's unlikely that people intend to lock the data input periods based on the time zone they are currently in. The current date picker logic would have to be modified significantly to provide some differentiation of local vs. server time, which would probably be confusing to most users.