### PR TITLE
ci: update node version to 14

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -21,7 +21,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
-                  node-version: 12.x
+                  node-version: 14.x
 
             - uses: actions/cache@v2
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -41,7 +41,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
-                  node-version: 12.x
+                  node-version: 14.x
 
             - uses: actions/cache@v2
               id: yarn-cache
@@ -68,7 +68,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
-                  node-version: 12.x
+                  node-version: 14.x
 
             - uses: actions/cache@v2
               id: yarn-cache
@@ -87,7 +87,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
-                  node-version: 12.x
+                  node-version: 14.x
 
             - uses: actions/cache@v2
               id: yarn-cache
@@ -109,7 +109,7 @@ jobs:
 
             - uses: actions/setup-node@v1
               with:
-                  node-version: 12.x
+                  node-version: 14.x
 
             - uses: actions/download-artifact@v2
               with:
@@ -135,7 +135,7 @@ jobs:
 
             - uses: actions/setup-node@v1
               with:
-                  node-version: 12.x
+                  node-version: 14.x
 
             - name: Publish release to GitHub
               run: npx @dhis2/cli-utils release


### PR DESCRIPTION
This updates the base node version for this app's workflows to v14. Install was failing because not all our deps support v12.