### PR TITLE
fix(program): replace use of Array.sort

### DIFF
--- a/src/EditModel/event-program/program-access/utils.js
+++ b/src/EditModel/event-program/program-access/utils.js
@@ -7,16 +7,16 @@ export const areSharingPropertiesSimilar = (a, b) => {
     const compareFunction = (a, b) => a.id < b.id;
     if (
         !isEqual(
-            Array.sort(a.userAccesses || [], compareFunction),
-            Array.sort(b.userAccesses || [], compareFunction),
+            a.userAccesses?.sort(compareFunction),
+            b.userAccesses?.sort(compareFunction),
         )
     ) {
         return false;
     }
 
     return isEqual(
-        Array.sort(a.userGroupAccesses || [], compareFunction),
-        Array.sort(b.userGroupAccesses || [], compareFunction),
+        a.userGroupAccesses?.sort(compareFunction),
+        b.userGroupAccesses?.sort(compareFunction)
     );
 };
 


### PR DESCRIPTION
[Older versions of `babel-polyfill` monkey patched `Array` to add an `Array.sort` function](https://github.com/babel/babel/blob/6.x/packages/babel-polyfill/src/index.js#L26-L28). Now that this app has been updated to the app platform, babel polyfill is no longer included and any code referencing `Array.sort` no longer works.