### PR TITLE
fix(relationship-type): use default-programStage for event-programs

### DIFF
--- a/src/config/field-overrides/relationshipType.js
+++ b/src/config/field-overrides/relationshipType.js
@@ -56,11 +56,11 @@ const modelTypesForRelationshipEntity = {
     PROGRAM_STAGE_INSTANCE: [
         {   
             // This is only used to render the selectors
-            // programStage is to identify the program regardless of programType
+            // programStage is used to identify the program regardless of programType
             modelType: 'program',
             mutex: 'programStage',
             required: true,
-            // exclude from posted value, "default"-programStage is used instead
+            // exclude from posted value, "default"-programStage is used in case of event-program
             excludeFromValue: true,
         },
         {
@@ -108,9 +108,7 @@ class Constraint extends Component {
 
         When Program Stage Instance is selected, we need to know the programType for selected programs, so we keep a reference to the model.
         We use the program-dropdown as a 'filter' (for trackerprograms) to only show programStages for the selected program,
-        however we cannot post this value to the server together with a programStage, as that results in an error.
-        If the selected program is a tracker-program, it should also be possible to further select a programStage
-        to narrow down the relationship. However this is optional, and if its not selected, we just post the programID.
+        however we cannot post the `program` value to the server together with a programStage, as that results in an error.
         Therefore we save the selected values in the state. */
 
         let selected = null;

--- a/src/config/field-overrides/relationshipType.js
+++ b/src/config/field-overrides/relationshipType.js
@@ -22,6 +22,9 @@ const relationshipEntities = {
 const isEventProgram = model =>
     model && model.programType === 'WITHOUT_REGISTRATION';
 
+const isTrackerProgram = model =>
+    model && model.programType === 'WITH_REGISTRATION';
+
 // Map of the different valid selection of the embedded objects, according to selected constraint-type
 const modelTypesForRelationshipEntity = {
     TRACKED_ENTITY_INSTANCE: [
@@ -51,7 +54,9 @@ const modelTypesForRelationshipEntity = {
         },
     ],
     PROGRAM_STAGE_INSTANCE: [
-        {
+        {   
+            // This is only used to render the selectors
+            // programStage is to identify the program regardless of programType
             modelType: 'program',
             mutex: 'programStage',
             required: true,
@@ -59,7 +64,7 @@ const modelTypesForRelationshipEntity = {
             excludeFromValue: true,
         },
         {
-            modelType: 'programStage', //This is only used for Tracker-programs
+            modelType: 'programStage',
             mutex: 'program',
             required: true,
             filter: (props, state) => {
@@ -218,7 +223,7 @@ class Constraint extends Component {
         if (modelType === 'program' && isEventProgram(value)) {
             prevState = {
                 ...prevState,
-                programStage: first(value.programStages.toArray())
+                programStage: first(value.programStages.toArray()),
             };
         }
 
@@ -250,13 +255,9 @@ class Constraint extends Component {
         }));
     };
 
-    hasSelectedEventProgram = () =>
-        has('selected.program', this.state) &&
-        this.state.selected.program.programType === 'WITHOUT_REGISTRATION';
-
     hasSelectedTrackerProgram = () =>
         has('selected.program', this.state) &&
-        this.state.selected.program.programType === 'WITH_REGISTRATION';
+        isTrackerProgram(this.state.selected.program);
 
     handleOptionsLoaded = (modelType, options) => {
         // get reference to already selected constraint
@@ -264,7 +265,7 @@ class Constraint extends Component {
         if (!this.state.selected) return;
         const selectedModelID =
             this.state.selected[modelType] && this.state.selected[modelType].id;
-        const option = options.find(opt => opt.value == selectedModelID);
+        const option = options.find(opt => opt.value === selectedModelID);
         if (option) {
             this.setState(state => ({
                 selected: {

--- a/src/forms/form-fields/drop-down-async.js
+++ b/src/forms/form-fields/drop-down-async.js
@@ -95,7 +95,7 @@ class DropDownAsync extends Component {
              * attributeselector to work when changing programs.
              */
 
-            fieldsForReferenceType = 'id,displayName,programType,programTrackedEntityAttributes[id,trackedEntityAttribute[id,displayName,valueType]]';
+            fieldsForReferenceType = 'id,displayName,programType,programTrackedEntityAttributes[id,trackedEntityAttribute[id,displayName,valueType]],programStages[id]';
         }
         // Need trackedEntityAttribute-ids for trackerProgram to assign programTrackedEntityAttributes
         if (props.referenceType === 'trackedEntityType') {


### PR DESCRIPTION
Fixes [DHIS2-13855](https://dhis2.atlassian.net/browse/DHIS2-13855) which prevented saving `relationShipTypes` with constraint-type `Event in program or program stage` to be saved. This is due to an API-change in 2.39.

Removed the ability for tracker-programs to just post a "program". Payload will now always use the `programStage`, and thus we cannot post a program without a `programStage`.

Event-programs will now use the default-programStage instead of `program.id`. 

Backport: https://github.com/dhis2/maintenance-app/pull/2332

