### PR TITLE
fix(options): fix attributeValues for options

### DIFF
--- a/src/EditModel/option-set/actions.js
+++ b/src/EditModel/option-set/actions.js
@@ -23,7 +23,7 @@ export async function loadOptionsForOptionSet(optionSetId, paging) {
 
     return d2.models.option
         .filter().on('optionSet.id').equals(optionSetId)
-        .list({ fields: ':all,attributeValues[:owner,attribute[id,name]', paging });
+        .list({ fields: ':all,attributeValues[:owner,value,attribute[id,name,displayName]]', paging });
 }
 
 function processResponse(options) {


### PR DESCRIPTION

Backport of #2388 
https://dhis2.atlassian.net/browse/DHIS2-14152

Options didn't load the value of the attributeValue correctly. This was due to 2 bugs: one bracket was missing in the field-filter, and it used :owner (instead of :all, like all other requests for attributeValues uses) - but I do think it's better to be explicit and include value instead of switching to :all.