### PR TITLE
fix: update authority for locales modules [DHIS2-14290]

### DIFF
--- a/src/config/custom-models/locale/LocaleModelDefinition.js
+++ b/src/config/custom-models/locale/LocaleModelDefinition.js
@@ -19,9 +19,9 @@ export default class LocaleModelDefinition extends ModelDefinition {
             this.api.get('me/authorization'),
         ]).then(([locales, authorities]) => {
             const deleteAuthorities = ['F_SYSTEM_SETTING', 'ALL']
-            const addAuthorities = [...deleteAuthorities, 'F_LOCALE_ADD']
+            const addAuthorities = ['F_LOCALE_ADD']
             const canDelete = authorities.some(auth => deleteAuthorities.includes(auth));
-            const canAdd = authorities.some(auth => addAuthorities.includes(auth));
+            const canAdd = canDelete || authorities.some(auth => addAuthorities.includes(auth));
 
             const access = {
                 read: true,

--- a/src/config/custom-models/locale/LocaleModelDefinition.js
+++ b/src/config/custom-models/locale/LocaleModelDefinition.js
@@ -18,13 +18,17 @@ export default class LocaleModelDefinition extends ModelDefinition {
             this.api.get('locales/dbLocales'),
             this.api.get('me/authorization'),
         ]).then(([locales, authorities]) => {
-            const canCreateAndDelete = authorities.some(auth => ['F_SYSTEM_SETTING', 'ALL'].includes(auth));
+            const deleteAuthorities = ['F_SYSTEM_SETTING', 'ALL']
+            const addAuthorities = [...deleteAuthorities, 'F_LOCALE_ADD']
+            const canDelete = authorities.some(auth => deleteAuthorities.includes(auth));
+            const canAdd = authorities.some(auth => addAuthorities.includes(auth));
+
             const access = {
                 read: true,
-                update: canCreateAndDelete,
+                update: canAdd,
                 externalize: false,
-                delete: canCreateAndDelete,
-                write: canCreateAndDelete,
+                delete: canDelete,
+                write: canAdd,
                 manage: false,
             };
 

--- a/src/config/custom-models/locale/localeSchemaDefinition.js
+++ b/src/config/custom-models/locale/localeSchemaDefinition.js
@@ -14,12 +14,14 @@ const localeSchemaDefinition = {
             type: 'CREATE_PUBLIC',
             authorities: [
                 'F_SYSTEM_SETTING',
+                'F_LOCALE_ADD',
             ],
         },
         {
             type: 'CREATE_PRIVATE',
             authorities: [
                 'F_SYSTEM_SETTING',
+                'F_LOCALE_ADD',
             ],
         },
         {


### PR DESCRIPTION
This adds `F_LOCALE_ADD` as an authority that lets users access Locales module in the maintenance app.

I've tested and confirmed that a user with `F_LOCALE_ADD` can add a locale but cannot delete. There does not appear to be a corresponding `F_LOCALE_DELETE`. 

I've added `F_LOCALE_ADD` in places where `F_SYSTEM_SETTING` was referenced, though I believe some of the references like adding it under `CREATE_PRIVATE` in localeSchemaDefinition.js might not be strictly necessary (e.g. I think the database locales are all public)?