### PR TITLE
fix: remove irrelevant fields for progRulAct update [DHIS2-14462]

### DIFF
--- a/src/config/field-overrides/program-rules/programRuleActionDialog.component.js
+++ b/src/config/field-overrides/program-rules/programRuleActionDialog.component.js
@@ -250,8 +250,15 @@ class ProgramRuleActionDialog extends React.Component {
             option: this.state.options,
             optionGroup: this.state.optionGroups,
         };
+
+        const currentActionType = programRuleAction.programRuleActionType;
+        const relevantFields = [
+            ...(programRuleActionTypes[currentActionType].required || []),
+            ...(programRuleActionTypes[currentActionType].optional || []),
+        ];
+
         Object.keys(fieldRefs).forEach(field => {
-            if (programRuleAction[field]) {
+            if (programRuleAction[field] && relevantFields.includes(field)) {
                 const ref = fieldRefs[field].find(
                     v => v.value === programRuleAction[field]
                 );


### PR DESCRIPTION
See [DHIS2-14462](https://dhis2.atlassian.net/browse/DHIS2-14462). Program Rule Actions have been updated to remove references to fields that are not defined as required/optional in programRuleActionTypes upon save.

[DHIS2-14462]: https://dhis2.atlassian.net/browse/DHIS2-14462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ