### PR TITLE
fix: add code to categoryOptionGroupset [DHIS2-12749]

### DIFF
--- a/src/config/field-config/field-order.js
+++ b/src/config/field-config/field-order.js
@@ -72,6 +72,7 @@ const fieldOrderByName = new Map([
     ['categoryOptionGroupSet', [
         'name',
         'shortName',
+        'code',
         'description',
         'dataDimension',
         'dataDimensionType',


### PR DESCRIPTION
See [DHIS2-12749](https://dhis2.atlassian.net/browse/DHIS2-12749)

Adds 'code' field to categoryOptionGroupSets:

**Before**
<img width="1384" alt="image" src="https://user-images.githubusercontent.com/18490902/215053351-4572d2d2-fb6e-4b2d-af16-576192617522.png">

**After**
<img width="1383" alt="image" src="https://user-images.githubusercontent.com/18490902/215053486-caec72a9-e8f3-4932-a222-9bdbf0edaa35.png">

I've tested and not noticed any issues.

[DHIS2-12749]: https://dhis2.atlassian.net/browse/DHIS2-12749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ