### PR TITLE
ci(concurrency): ensure only one verify-app wf runs at a time

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -4,6 +4,9 @@ on:
     push:
         branches:
 
+concurrency:
+    group: ${{ github.workflow}}-${{ github.ref }}
+
 env:
     GIT_AUTHOR_NAME: '@dhis2-bot'
     GIT_AUTHOR_EMAIL: 'apps@dhis2.org'


### PR DESCRIPTION
See: https://dhis2.slack.com/archives/CJF3MDK8Q/p1674742870916349 and https://docs.github.com/en/actions/using-jobs/using-concurrency

This is already in our upstream workflows (https://github.com/dhis2/workflows), but the workflows in this repo are behind. The concurrency setting ensures that per group only one run will run at a time.

For reference, the github ref value docs are:

![image](https://user-images.githubusercontent.com/7355199/215527463-1e1d0744-d10f-4b9f-a3b6-220b0931ce25.png)

So basically one run for this workflow will run per branch (https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)