### PR TITLE
fix: sort options by sort order [DHIS2-14602]

### DIFF
--- a/src/EditModel/option-set/OptionManagement.component.js
+++ b/src/EditModel/option-set/OptionManagement.component.js
@@ -107,21 +107,6 @@ class OptionManagement extends Component {
         translate: true,
     });
 
-    displayInCorrectOrderWarning() {
-        if (!(this.props.pager && this.props.pager.total > 50)) {
-            return null;
-        }
-
-        return (
-            <div style={styles.alertWrapper}>
-                <AlertIcon color="orange" />
-                <div style={styles.alertText}>
-                    {this.i18n.getTranslation('list_might_not_represent_the_accurate_order_of_options_due_the_availability_of_pagination')}
-                </div>
-            </div>
-        );
-    }
-
     isContextActionAllowed = (model, action) => {
         if (!model || !model.access) {
             return false;
@@ -190,7 +175,6 @@ class OptionManagement extends Component {
 
         return (
             <div style={styles.optionManagementWrap}>
-                {this.displayInCorrectOrderWarning()}
                 {this.renderPagination()}
                 <OptionSorter
                     style={styles.sortBarStyle}

--- a/src/EditModel/option-set/actions.js
+++ b/src/EditModel/option-set/actions.js
@@ -23,7 +23,7 @@ export async function loadOptionsForOptionSet(optionSetId, paging) {
 
     return d2.models.option
         .filter().on('optionSet.id').equals(optionSetId)
-        .list({ fields: ':all,attributeValues[:owner,value,attribute[id,name,displayName]]', paging });
+        .list({ fields: ':all,attributeValues[:owner,value,attribute[id,name,displayName]]', paging, order: 'sortOrder:asc' });
 }
 
 function processResponse(options) {

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -509,7 +509,6 @@ intro_option_set=Create option sets which can be included in data elements and p
 manual_sorting_is_not_available_for_option_sets_with_more_than_50_options=Manual sorting is not available for option sets with more than 50 options
 sort_manually=Sort manually
 failed_to_save_order=Failed to save order
-list_might_not_represent_the_accurate_order_of_options_due_the_availability_of_pagination=List might not represent the accurate order of options due to the availability of pagination
 option_edit=Edit option
 option_add=Add option
 option_saved=Option saved


### PR DESCRIPTION
This PR updates option set ordering in the maintenance app to sort options by sort order (and removes the existing messaging about option being potentially displayed in the incorrect order).

(note this helps facilitate the PR for [DHIS2-13714](https://dhis2.atlassian.net/browse/DHIS2-13714), so the we can use natural sort and then display the options back to the user in the correct order)

**Before**

<img width="1380" alt="image" src="https://user-images.githubusercontent.com/18490902/221587454-dd9dbc48-e6a7-4d27-b8c8-32cf32ca8fc8.png">


**After**
<img width="1374" alt="image" src="https://user-images.githubusercontent.com/18490902/221587544-9d8fad2b-b0ae-4fdd-86d4-628a50bd11e8.png">


[DHIS2-13714]: https://dhis2.atlassian.net/browse/DHIS2-13714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ