### PR TITLE
fix: use en as default for localeCompare

### DIFF
--- a/src/EditModel/option-set/OptionSorter/optionSorter.js
+++ b/src/EditModel/option-set/OptionSorter/optionSorter.js
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs';
 export default function optionSorter(options, sortProperty, sortOrder = 'ASC') {
     const sortedOptions = options.sort((left, right) =>
         (left[sortProperty] || '')
-            .localeCompare(right[sortProperty],undefined, {numeric: true}));
+            .localeCompare(right[sortProperty], 'en', {numeric: true}));
 
     return Observable
         .of(sortOrder === 'ASC'


### PR DESCRIPTION
Follow up for https://dhis2.atlassian.net/browse/DHIS2-13714

There appears to be some browser-dependent bug where localeCompare does not sort properly if `undefined` locale is used. In this case, the default locale should be used, but this seems to be resulting in `a` being sorted at the end of the alphabet 🤪

I think changing to 'en' as the default locale for sorting is fine. I'm not sure what's better from a user perspective anyway (letting sort depend on user settings, or assume one consistent sort order).

**Before**
See [comment](https://dhis2.atlassian.net/browse/DHIS2-13714?focusedCommentId=182010) (`aa` appears at end)

**After:**
![sort_order_name](https://user-images.githubusercontent.com/18490902/233111557-91241237-717d-435d-adef-a9cc3317af70.gif)

