### PR TITLE
fix: use en as default for localeCompare

### DIFF
--- a/src/EditModel/option-set/OptionSorter/optionSorter.js
+++ b/src/EditModel/option-set/OptionSorter/optionSorter.js
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs';
 export default function optionSorter(options, sortProperty, sortOrder = 'ASC') {
     const sortedOptions = options.sort((left, right) =>
         (left[sortProperty] || '')
-            .localeCompare(right[sortProperty],undefined, {numeric: true}));
+            .localeCompare(right[sortProperty], 'en', {numeric: true}));
 
     return Observable
         .of(sortOrder === 'ASC'


### PR DESCRIPTION
backport of https://github.com/dhis2/maintenance-app/pull/2462