### PR TITLE
fix: program indicator clean up [DHIS2-14951]

### DIFF
--- a/src/config/field-overrides/program-indicator/VariableSelector.js
+++ b/src/config/field-overrides/program-indicator/VariableSelector.js
@@ -29,6 +29,8 @@ const programIndicatorVariables = [
     'sync_date',
     'value_count',
     'zero_pos_value_count',
+    'analytics_period_start',
+    'analytics_period_end',
 ];
 // See https://jira.dhis2.org/browse/DHIS2-6256 for reference
 // Hidden if true
@@ -37,7 +39,7 @@ const conditionalPIVariables = {
     enrollment_date: isEventProgram,
     enrollment_status: isEventProgram,
     event_count: overSome([isFilterType, isAggregationTypeNotCount]),
-    org_unit_count: isFilterType,
+    org_unit_count:  overSome([isFilterType, isAggregationTypeNotCount]),
     incident_date: isEventProgram,
     program_stage_id: isAnalyticsTypeEnrollment,
     program_stage_name: isAnalyticsTypeEnrollment,

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -1962,6 +1962,8 @@ zero_pos_value_count=Zero or positive value count
 event_count=Event count
 org_unit_count=Organisation unit count
 analytics_type=Analytics type
+analytics_period_start=Analytics period start
+analytics_period_end=Analytics period end
 
 programIndicator__expression__help_text=The expression defines how the indicator is calculated. Tip: use d2:condition('bool-expr',true-val,false-val) d2:daysBetween(date,date) d2:zing(x) d2:oizp(x)
 programIndicator__filter__help_text=The filter is applied to events and filters the data source used for the calculation of the indicator. The filter must evaluate to either true or false. Use single quotes for text values. Use option codes for option set references. Tip: use d2:condition('bool-expr',true-val,false-val) d2:daysBetween(date,date) d2:zing(x) d2:oizp(x)


### PR DESCRIPTION
See ticket https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-14951

We discussed this on [DHIS2 slack](https://dhis2.slack.com/archives/C45MWQ1QS/p1679313600408889), and it was decided that we would make the following updates in the maintenance app:

- add `analytics_period_start` and `analytics_period_end` 
- display org_unit_count variable only when program indicator aggregation type is Count

We also have some documentation updates and are determining the necessary updates for `event_status`