### PR TITLE
fix(programindicators): default period boundary

### DIFF
--- a/src/config/field-config/field-defaults.js
+++ b/src/config/field-config/field-defaults.js
@@ -1,5 +1,3 @@
-import { isEqual } from 'lodash/fp';
-
 import {
     BEFORE_END_OF_REPORTING_PERIOD,
     AFTER_START_OF_REPORTING_PERIOD,

--- a/src/config/field-config/field-defaults.js
+++ b/src/config/field-config/field-defaults.js
@@ -7,9 +7,9 @@ import {
     ENROLLMENT_DATE,
 } from '../field-overrides/program-indicator/enums';
 
-export function defaultAnalyticsPeriodBoundaries(type, current) {
-    const defaultProps = {
-        enrollment: [
+export function defaultAnalyticsPeriodBoundaries(type) {
+    const defaultBoundaries = {
+        ENROLLMENT: [
             {
                 analyticsPeriodBoundaryType: AFTER_START_OF_REPORTING_PERIOD,
                 boundaryTarget: ENROLLMENT_DATE,
@@ -19,7 +19,7 @@ export function defaultAnalyticsPeriodBoundaries(type, current) {
                 boundaryTarget: ENROLLMENT_DATE,
             },
         ],
-        event: [
+        EVENT: [
             {
                 analyticsPeriodBoundaryType: AFTER_START_OF_REPORTING_PERIOD,
                 boundaryTarget: EVENT_DATE,
@@ -30,17 +30,7 @@ export function defaultAnalyticsPeriodBoundaries(type, current) {
             },
         ],
     };
-
-    function isNotDefault(val) {
-        return !isEqual(val, defaultProps.event)
-            && !isEqual(val, defaultProps.enrollment);
-    }
-
-    if (current && isNotDefault(current)) {
-        return current;
-    }
-
-    return defaultProps[type];
+    return defaultBoundaries[type];
 }
 
 /**

--- a/src/config/field-rules.js
+++ b/src/config/field-rules.js
@@ -601,22 +601,6 @@ export default new Map([
         createDefaultRuleForField('validationStrategy', "ON_UPDATE_AND_INSERT"),
     ]],
     ['programIndicator', [{
-        field: 'analyticsPeriodBoundaries',
-        when: [{
-            field: 'analyticsType',
-            operator: 'EQUALS',
-            value: 'EVENT',
-        }],
-        operations: [{
-            type: 'CHANGE_VALUE',
-            setValue: (model, fieldConfig) => {
-                if (fieldConfig) {
-                    fieldConfig.value = defaultAnalyticsPeriodBoundaries('event', fieldConfig.value);
-                    model[fieldConfig.name] = defaultAnalyticsPeriodBoundaries('event', fieldConfig.value);
-                }
-            },
-        }],
-    },{
         field: 'orgUnitField',
         when: [{
             field: 'program',
@@ -631,19 +615,30 @@ export default new Map([
         field: 'analyticsPeriodBoundaries',
         when: [{
             field: 'analyticsType',
-            operator: 'EQUALS',
-            value: 'ENROLLMENT',
+            operator: 'HAS_VALUE',
         }],
         operations: [{
             type: 'CHANGE_VALUE',
             setValue: (model, fieldConfig) => {
                 if (fieldConfig) {
-                    fieldConfig.value = defaultAnalyticsPeriodBoundaries('enrollment', fieldConfig.value);
-                    model[fieldConfig.name] = defaultAnalyticsPeriodBoundaries('enrollment', fieldConfig.value);
+                    const prevAnalyticsType = fieldConfig.previousAnalyticsType;
+                    const analyticsType = model.analyticsType
+                    const currentBoundaries = fieldConfig.value;
+                    const didChange = prevAnalyticsType && prevAnalyticsType !== analyticsType;
+
+                    if(!currentBoundaries || didChange) {
+                        const defaultValue = defaultAnalyticsPeriodBoundaries(analyticsType, fieldConfig.value);
+                        fieldConfig.value = defaultValue;
+                        model[fieldConfig.name] = defaultValue;
+                    }
+                    // save previous analytics type to be able to check if it has changed
+                    // no other good way to check, since all rules are run on every change
+                    fieldConfig.previousAnalyticsType = analyticsType;
                 }
-            },
-        }],
-    }]],
+            }
+        }]
+    },
+    ]],
     ['programStageNotificationTemplate', [
         {
             field: 'notificationTrigger',


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-15205

I'm a bit confused by the previous logic for setting the default boundaries, and it didn't seem to comply to the specs, since it did not correctly reset the boundaries when `analyticsType` changed. It would only reset the boundaries if they were equal to some default - but that is the origin of the bug described in the ticket above as well; it would prevent setting the boundaries that happened to be equal to the other types default (eg. type `Enrollment`, and both boundary targets `Event date` .

It might've been a workaround due it being hard to know if only the `analyticsTápe` changed without a variable for it - so I included that in a small hack.
