### PR TITLE
fix(programrule): rename program stage to hide label

### DIFF
--- a/src/config/field-overrides/program-rules/programRuleActionTypes.js
+++ b/src/config/field-overrides/program-rules/programRuleActionTypes.js
@@ -37,7 +37,7 @@ const actionTypeFieldMapping = {
         label: 'prevent_adding_new_events_to_stage', // see https://dhis2.atlassian.net/browse/DHIS2-13995
         required: ['programStage'],
         labelOverrides: {
-            programStage: 'program_stage_to_hide',
+            programStage: 'program_stage',
         },
     },
     HIDEOPTION: {


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-13995

Issue has been merged, but decided to also rename the label for the `program stage` dropdown to just `Program stage`.