### PR TITLE
fix(program): migrate from legacy sharing API

### DIFF
--- a/src/App/appStateStore.js
+++ b/src/App/appStateStore.js
@@ -70,7 +70,7 @@ async function getCurrentUserOrganisationUnits(disableCache = false) {
 
     const d2 = await getInstance();
     const organisationUnitsCollection = await d2.currentUser.getOrganisationUnits({
-        fields: ':all,displayName,path,publicAccess,access,children[id,displayName,path,children::isNotEmpty,publicAccess,access]',
+        fields: ':all,displayName,path,access,children[id,displayName,path,children::isNotEmpty,sharing,access]',
         paging: false
     });
 
@@ -79,8 +79,8 @@ async function getCurrentUserOrganisationUnits(disableCache = false) {
             level: 1,
             paging: false,
             fields: [
-                'id,displayName,path,publicAccess,access,lastUpdated',
-                'children[id,displayName,publicAccess,access,path,children::isNotEmpty]',
+                'id,displayName,path,sharing,access,lastUpdated',
+                'children[id,displayName,sharing,access,path,children::isNotEmpty]',
             ].join(','),
         });
 

--- a/src/EditModel/event-program/epics.js
+++ b/src/EditModel/event-program/epics.js
@@ -148,9 +148,6 @@ function loadEventProgramMetadataByProgramId(programPayload) {
         'notificationTemplates[:owner]',
         'programTrackedEntityAttributes',
         'user[id,name]',
-        'publicAccess',
-        'userGroupAccesses',
-        'userAccesses',
         'categoryCombo[id,name]'
     ].join(',');
 
@@ -159,7 +156,7 @@ function loadEventProgramMetadataByProgramId(programPayload) {
     const queryParams = {
         fields: ':owner,displayName',
         'programs:filter': `id:eq:${programId}`,
-        'programs:fields': `${programFields},programStages[:owner, publicAccess, userGroupAccesses, userAccesses, user[id,name],displayName,attributeValues[:all,attribute[id,name,displayName]],programStageDataElements[:owner,renderType,dataElement[id,displayName,valueType,optionSet,domainType]],notificationTemplates[:owner,displayName],dataEntryForm[:owner],programStageSections[:owner,displayName,dataElements[id,displayName]]]`,
+        'programs:fields': `${programFields},programStages[:owner,user[id,name],displayName,attributeValues[:all,attribute[id,name,displayName]],programStageDataElements[:owner,renderType,dataElement[id,displayName,valueType,optionSet,domainType]],notificationTemplates[:owner,displayName],dataEntryForm[:owner],programStageSections[:owner,displayName,dataElements[id,displayName]]]`,
         'dataElements:fields': 'id,displayName,valueType,optionSet',
         'dataElements:filter': 'domainType:eq:TRACKER',
         'trackedEntityAttributes:fields': 'id,displayName,valueType,optionSet,unique'

--- a/src/EditModel/event-program/event-program-store/getMetaDataToSend.js
+++ b/src/EditModel/event-program/event-program-store/getMetaDataToSend.js
@@ -27,21 +27,11 @@ const hasDirtyProgramNotifications = state => programNotificationsSelector(state
 const hasDirtyDataEntryForms = compose(some(checkIfDirty), values, dataEntryFormsSelector);
 const hasDirtyProgramSections = compose(some(checkIfDirty), values, programSectionsSelector);
 
-/* Sharing settings was removed from :owner properties in 2.36
-    In programs we are using metadata API (instead of /sharing-api),
-    so we still need to include these properties
-*/
-const modelToJsonWithSharingProperties = model => {
-    const ownerProperties = model.modelDefinition.getOwnedPropertyNames()
-    const sharingProperties = ['publicAccess', 'userAccesses', 'userGroupAccesses']
-    return getJSONForProperties(model, ownerProperties.concat(sharingProperties))
-}
-
 const handleDataEntryForm = state => payload => {
     if (isProgramDirty(state)) {
         const withPrograms = {
             ...payload,
-            programs: [programSelector(state)].map(modelToJsonWithSharingProperties)
+            programs: [programSelector(state)].map(modelToJson)
         }
 
         //For custom-form
@@ -65,7 +55,7 @@ const handleProgramStages = state => payload => {
     if (isProgramStageDirty(state)) {
         return {
             ...payload,
-            programStages: programStagesSelector(state).map(modelToJsonWithSharingProperties)
+            programStages: programStagesSelector(state).map(modelToJson)
         }
     }
 

--- a/src/EditModel/event-program/program-access/ProgramAccess.js
+++ b/src/EditModel/event-program/program-access/ProgramAccess.js
@@ -15,12 +15,16 @@ const styles = {
     }
 };
 
-const ProgramNotSavedMessage = () => (
-    <div>Save the program in order to access sharing settings</div>
+const ProgramNotSavedMessage = (_, { d2 } ) => (
+    <div>{d2.i18n.getTranslation('save_the_program_in_order_to_access_sharing_settings')}</div>
 );
 
+ProgramNotSavedMessage.contextTypes = {
+    d2: PropTypes.object,
+}
+
 const ProgramStagesAccessHOC = branch(
-    props => !props.model.dataValues.publicAccess,
+    props => !props.model.dataValues.sharing,
     renderComponent(ProgramNotSavedMessage)
 )(ProgramStagesAccess);
 

--- a/src/EditModel/event-program/program-access/utils.js
+++ b/src/EditModel/event-program/program-access/utils.js
@@ -1,31 +1,37 @@
 import { isEqual } from 'lodash/fp';
 
+
+const sortSharingObjectPart = (sharingObjectPart) => {
+    if(!sharingObjectPart) return sharingObjectPart;
+
+    return Object.values(sharingObjectPart).sort((a, b) => a.id < b.id);
+}
+
 export const areSharingPropertiesSimilar = (modelA, modelB) => {
     const sharingA = modelA.sharing;
     const sharingB = modelB.sharing;
-    if (sharingA.public !== sharingB.public) return false;
+    if (!sharingA || !sharingB || sharingA.public !== sharingB.public) return false;
     if (!!sharingA.externalAccess !== !!sharingB.externalAccess) return false;
 
-    const compareFunction = (a, b) => a.id < b.id;
     if (
         !isEqual(
-            Array.sort(sharingA.users || [], compareFunction),
-            Array.sort(sharingB.users || [], compareFunction),
+            sortSharingObjectPart(sharingA.users),
+            sortSharingObjectPart(sharingB.users),
         )
     ) {
         return false;
     }
 
     return isEqual(
-        Array.sort(sharingA.userGroups || [], compareFunction),
-        Array.sort(sharingB.userGroups || [], compareFunction),
+        sortSharingObjectPart(sharingA.userGroups),
+        sortSharingObjectPart(sharingB.userGroups)
     )
 };
 
 export const extractDisplayName = model => model.dataValues.displayName;
 
 const getPublicAccessDescription = publicAccessString => {
-    if (publicAccessString.substr(0, 4) === '----') return 'No public access';
+    if (!publicAccessString || publicAccessString.substr(0, 4) === '----') return 'No public access';
     if (publicAccessString.substr(0, 4) === 'rwrw') return 'Complete public access';
 
     let description = '';
@@ -54,7 +60,7 @@ const getPublicAccessDescription = publicAccessString => {
 };
 
 export const generateSharingDescription = ({ sharing }) => {
-    const { public: publicAccess, users, userGroups } = sharing;
+    const { public: publicAccess, users, userGroups } = sharing || {};
     const publicAccessDescription = getPublicAccessDescription(publicAccess);
     const userGroupCount = userGroups ? Object.keys(userGroups).length : 0;
     const userCount = users ? Object.keys(users).length : 0;

--- a/src/EditModel/event-program/program-access/utils.js
+++ b/src/EditModel/event-program/program-access/utils.js
@@ -1,33 +1,35 @@
 import { isEqual } from 'lodash/fp';
 
-export const areSharingPropertiesSimilar = (a, b) => {
-    if (a.publicAccess !== b.publicAccess) return false;
-    if (!!a.externalAccess !== !!b.externalAccess) return false;
+export const areSharingPropertiesSimilar = (modelA, modelB) => {
+    const sharingA = modelA.sharing;
+    const sharingB = modelB.sharing;
+    if (sharingA.public !== sharingB.public) return false;
+    if (!!sharingA.externalAccess !== !!sharingB.externalAccess) return false;
 
     const compareFunction = (a, b) => a.id < b.id;
     if (
         !isEqual(
-            Array.sort(a.userAccesses || [], compareFunction),
-            Array.sort(b.userAccesses || [], compareFunction),
+            Array.sort(sharingA.users || [], compareFunction),
+            Array.sort(sharingB.users || [], compareFunction),
         )
     ) {
         return false;
     }
 
     return isEqual(
-        Array.sort(a.userGroupAccesses || [], compareFunction),
-        Array.sort(b.userGroupAccesses || [], compareFunction),
-    );
+        Array.sort(sharingA.userGroups || [], compareFunction),
+        Array.sort(sharingB.userGroups || [], compareFunction),
+    )
 };
 
 export const extractDisplayName = model => model.dataValues.displayName;
 
-const getPublicAccessDescription = publicAccess => {
-    if (publicAccess.substr(0, 4) === '----') return 'No public access';
-    if (publicAccess.substr(0, 4) === 'rwrw') return 'Complete public access';
+const getPublicAccessDescription = publicAccessString => {
+    if (publicAccessString.substr(0, 4) === '----') return 'No public access';
+    if (publicAccessString.substr(0, 4) === 'rwrw') return 'Complete public access';
 
     let description = '';
-    switch (publicAccess.substr(0, 2)) {
+    switch (publicAccessString.substr(0, 2)) {
         case 'rw':
             description += 'Public metadata read- and write access';
             break;
@@ -41,7 +43,7 @@ const getPublicAccessDescription = publicAccess => {
 
     description = description += ', ';
 
-    switch (publicAccess.substr(2, 2)) {
+    switch (publicAccessString.substr(2, 2)) {
         case 'rw':
             return description + 'public data read- and write access';
         case 'r-':
@@ -51,10 +53,11 @@ const getPublicAccessDescription = publicAccess => {
     }
 };
 
-export const generateSharingDescription = ({ publicAccess, userGroupAccesses, userAccesses }) => {
+export const generateSharingDescription = ({ sharing }) => {
+    const { public: publicAccess, users, userGroups } = sharing;
     const publicAccessDescription = getPublicAccessDescription(publicAccess);
-    const userGroupCount = userGroupAccesses ? userGroupAccesses.length : 0;
-    const userCount = userAccesses ? userAccesses.length : 0;
+    const userGroupCount = userGroups ? Object.keys(userGroups).length : 0;
+    const userCount = users ? Object.keys(users).length : 0;
 
     let description = publicAccessDescription;
     if (userCount || userGroupCount) {

--- a/src/EditModel/event-program/tracker-program/epics.js
+++ b/src/EditModel/event-program/tracker-program/epics.js
@@ -66,7 +66,12 @@ export const newTrackerProgramStage = action$ =>
             const maxSortOrder = getMaxSortOrder(store);
             const programStageModel = d2.models.programStages.create({
                 id: programStageUid,
-                publicAccess: "rw------",
+                sharing: {
+                    public: "rw------",
+                    userGroups: {},
+                    users: {},
+                    externalAccess: false
+                },
                 programStageDataElements: [],
                 notificationTemplates: [],
                 programStageSections: [],

--- a/src/EditModel/sharing.js
+++ b/src/EditModel/sharing.js
@@ -1,10 +1,13 @@
 /* Helpers to transform sharing properties of a model
 ` Before 2.41, sharing properties were on the root of the model
  
- publicAccess: 'rwrw----',
- externalAccess: false,
- userGroupAccesses: [],
+ "dataElement": {
+    publicAccess: 'rwrw----',
+    externalAccess: false,
+    userGroupAccesses: [],
     userAccesses: [],
+    ...otherProperties
+}
 
 After 2.41 these are grouped in a sharing object:
 
@@ -91,7 +94,7 @@ export const transformLegacySharingToSharingObject = modelWithSharing => {
     };
 };
 
-export const transformLegacySharingArrayToObject = sharingArray => {
+const transformLegacySharingArrayToObject = sharingArray => {
     return sharingArray.reduce((acc, sharing) => {
         acc[sharing.id] = {
             displayName: sharing.displayName,

--- a/src/EditModel/sharing.js
+++ b/src/EditModel/sharing.js
@@ -68,6 +68,14 @@ export const transformSharingObjectToLegacy = sharing => {
 /* Converts legacy sharing structure to sharing object
 note that this will not include owner property */
 export const transformLegacySharingToSharingObject = modelWithSharing => {
+    if(!modelWithSharing) {
+        return {
+            public: '--------',
+            external: false,
+            userGroups: {},
+            users: {},
+        };
+    }
     const {
         publicAccess,
         externalAccess,

--- a/src/EditModel/sharing.js
+++ b/src/EditModel/sharing.js
@@ -47,7 +47,7 @@ export const transformSharingObjectToLegacy = sharing => {
     const { public: publicAccess, users, userGroups, external } = sharing;
 
     return {
-        publicAccess,
+        publicAccess: publicAccess || '--------',
         externalAccess: Boolean(external),
         userGroupAccesses: userGroups
             ? Object.values(userGroups).map(userGroupSharing => ({
@@ -87,7 +87,7 @@ export const transformLegacySharingToSharingObject = modelWithSharing => {
     } = modelWithSharing;
 
     return {
-        public: publicAccess,
+        public: publicAccess || '--------',
         external: Boolean(externalAccess),
         userGroups: transformLegacySharingArrayToObject(userGroupAccesses),
         users: transformLegacySharingArrayToObject(userAccesses),

--- a/src/EditModel/sharing.js
+++ b/src/EditModel/sharing.js
@@ -1,0 +1,95 @@
+/* Helpers to transform sharing properties of a model
+` Before 2.41, sharing properties were on the root of the model
+ 
+ publicAccess: 'rwrw----',
+ externalAccess: false,
+ userGroupAccesses: [],
+    userAccesses: [],
+
+After 2.41 these are grouped in a sharing object:
+
+"sharing": {
+    "owner": "GOLswS44mh8",
+    "external": false,
+    "users": {},
+    "userGroups": {
+        "Rg8wusV7QYi": {
+        "displayName": "HIV Program Coordinators",
+        "access": "r-------",
+        "id": "Rg8wusV7QYi"
+        },
+        "qMjBflJMOfB": {
+        "displayName": "Family Planning Program",
+        "access": "rw------",
+        "id": "qMjBflJMOfB"
+        }
+    },
+    "public": "rw------"
+},
+ */
+
+/* Converts sharing object to legacy structure 
+    Some places in the app still need the legacy structure,
+    eg. the sharing-dialog expects props as arrays instead of objects */
+export const transformSharingObjectToLegacy = sharing => {
+    if (!sharing) {
+        return {
+            publicAccess: '--------',
+            externalAccess: false,
+            userGroupAccesses: [],
+            userAccesses: [],
+        };
+    }
+
+    const { public: publicAccess, users, userGroups, external } = sharing;
+
+    return {
+        publicAccess,
+        externalAccess: Boolean(external),
+        userGroupAccesses: userGroups
+            ? Object.values(userGroups).map(userGroupSharing => ({
+                  id: userGroupSharing.id,
+                  access: userGroupSharing.access,
+                  displayName: userGroupSharing.displayName,
+                  userGroupUid: userGroupSharing.id,
+              }))
+            : [],
+        userAccesses: users
+            ? Object.values(users).map(userSharing => ({
+                id: userSharing.id,
+                access: userSharing.access,
+                displayName: userSharing.displayName,
+                userUid: userSharing.id,
+              }))
+            : [],
+    };
+};
+
+/* Converts legacy sharing structure to sharing object
+note that this will not include owner property */
+export const transformLegacySharingToSharingObject = modelWithSharing => {
+    const {
+        publicAccess,
+        externalAccess,
+        userGroupAccesses,
+        userAccesses,
+    } = modelWithSharing;
+
+    return {
+        public: publicAccess,
+        external: Boolean(externalAccess),
+        userGroups: transformLegacySharingArrayToObject(userGroupAccesses),
+        users: transformLegacySharingArrayToObject(userAccesses),
+    };
+};
+
+export const transformLegacySharingArrayToObject = sharingArray => {
+    return sharingArray.reduce((acc, sharing) => {
+        acc[sharing.id] = {
+            displayName: sharing.displayName,
+            access: sharing.access,
+            id: sharing.id,
+        };
+        return acc;
+    }, {});
+};

--- a/src/List/List.component.js
+++ b/src/List/List.component.js
@@ -42,6 +42,7 @@ import DialogRouter from '../Dialog/DialogRouter';
 import ContextMenuHeader from './ContextMenuHeader'
 import { openDialog } from '../Dialog/actions';
 import * as DIALOGTYPES from '../Dialog/types';
+import { transformLegacySharingToSharingObject } from '../EditModel/sharing';
 
 const styles = {
     dataTableWrap: {
@@ -189,7 +190,7 @@ class List extends Component {
                 sharing: sharingState,
                 dataRows: state.dataRows.map((row) => {
                     if (row.id === sharingState.model.id) {
-                        return Object.assign(row, { publicAccess: sharingState.model.publicAccess });
+                        return Object.assign(row, { sharing: sharingState.model.sharing });
                     }
                     return row;
                 }),
@@ -333,8 +334,12 @@ class List extends Component {
     }
 
     closeSharingDialog = (sharingState) => {
+        // sharing dialog gives us a legacy sharing object, we want to transform it to the "new" sharing Object
+        // because that's what the format the list will have
+        // this is then transformed to "publicAccess" in the render, because DataTable expects that
+        const sharingObject = transformLegacySharingToSharingObject(sharingState)
         const model = sharingState
-            ? Object.assign(sharingStore.state.model, { publicAccess: sharingState.publicAccess })
+            ? Object.assign(sharingStore.state.model, { sharing: sharingObject })
             : sharingStore.state.model;
 
         sharingStore.setState(Object.assign({}, sharingStore.state, {
@@ -540,6 +545,15 @@ class List extends Component {
             }, row);
         };
 
+        const transformSharingObjectToPublicAccess = (model) => {
+            // the data-table has functionality for rendering "publicAccess"
+            // we thus need to transform the sharing object to a publicAccess property
+            if (model.sharing) {
+                model.publicAccess = model.sharing.public;
+            }
+            return model;
+        }
+
         const primaryAction = (model) => {
             if (model.access.write && model.modelDefinition.name !== 'locale') {
                 availableActions.edit(model);
@@ -586,6 +600,7 @@ class List extends Component {
                                                 .map(magicallyUnwrapChildValues)
                                                 .map(defaultReallyMeansNone)
                                                 .map(translateConstants)
+                                                .map(transformSharingObjectToPublicAccess)
                                         }
                                         columns={this.state.tableColumns}
                                         contextMenuActions={availableActions}

--- a/src/List/List.component.js
+++ b/src/List/List.component.js
@@ -549,7 +549,7 @@ class List extends Component {
             // the data-table has functionality for rendering "publicAccess"
             // we thus need to transform the sharing object to a publicAccess property
             if (model.sharing) {
-                model.publicAccess = model.sharing.public;
+                model.publicAccess = model.sharing.public || '--------';
             }
             return model;
         }

--- a/src/List/columns/ColumnConfigDialog.js
+++ b/src/List/columns/ColumnConfigDialog.js
@@ -187,8 +187,8 @@ export class ColumnConfigDialog extends Component {
  * Ignore some that are internal, no easy way to filter these without a blacklist
  *
  */
-function getAvailableColumnsForModel(model) {
-    const validations = model.modelValidations;
+function getAvailableColumnsForModel(modelDefinition) {
+    const validations = modelDefinition.modelValidations;
     const ignoreFieldTypes = new Set(['COLLECTION', 'REFERENCE', 'COMPLEX']);
     const ignoreFieldNames = new Set([
         'dimensionItem',
@@ -240,7 +240,13 @@ function getAvailableColumnsForModel(model) {
         }
     }
 
-    return availableColumns;
+    if(modelDefinition.isShareable) {
+        // this is not a property on the model (was removed and replaced with sharing object)
+        // however, we map `sharing.public` to `publicAccess` in list, so it's available there.
+        // thus we need to make it selectable in the column config dialog as well.
+        availableColumns.push('publicAccess');
+    }
+    return availableColumns
 }
 
 ColumnConfigDialog.contextTypes = {

--- a/src/List/list.actions.js
+++ b/src/List/list.actions.js
@@ -17,7 +17,7 @@ import {
 
 export const fieldFilteringForQuery = [
     'displayName', 'shortName', 'id', 'lastUpdated', 'created', 'displayDescription',
-    'code', 'publicAccess', 'access', 'href', 'level',
+    'code', 'sharing', 'access', 'href', 'level',
 ].join(',');
 
 //Set over schemas that should not filter out name=default
@@ -98,12 +98,18 @@ function getOrderingForSchema(modelName) {
 }
 
 export function getQueryForSchema(modelName) {
+    // remove fields from query
+    // note that these fields may still be used for "column"-types, to eg. show the field
+    // but we don't want to make requests with it, because they might've been removed or deprecated
+    const fieldsToRemove = new Set('publicAccess')
+
     return {
         fields: [
             fieldFilteringForQuery,
             getTableColumnsForType(modelName, true),
             getAdditionalFieldsForType(modelName),
-        ].join(),
+        ]
+            .filter(field => !fieldsToRemove.has(field)).join(),
         order: getOrderingForSchema(modelName),
     };
 }

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -2362,3 +2362,5 @@ note_label=Custom label for note
 tracked_entity_attribute_label=Custom label for tracked entity attribute
 sorting_is_disabled_when_filter_is_applied=Sorting is diabled when a filter is applied
 save_the_program_in_order_to_access_sharing_settings=Save the program in order to access sharing settings
+confirm_delete_icon=Are you sure you want to delete this icon?
+intro_icon=Upload, modify and view icons which can be used assigned to other metadata.

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -2361,3 +2361,4 @@ relationship_label=Custom label for relationship
 note_label=Custom label for note
 tracked_entity_attribute_label=Custom label for tracked entity attribute
 sorting_is_disabled_when_filter_is_applied=Sorting is diabled when a filter is applied
+save_the_program_in_order_to_access_sharing_settings=Save the program in order to access sharing settings

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ var dhisConfig;
 
 try {
     dhisConfig = require(dhisConfigPath);
-    // dhisConfig.baseUrl = 'https://debug.dhis2.org/dev',
+    dhisConfig.baseUrl = 'https://debug.dhis2.org/dev',
     console.log(dhisConfig);
 } catch (e) {
     // Failed to load config file - use default config

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ var dhisConfig;
 
 try {
     dhisConfig = require(dhisConfigPath);
-    dhisConfig.baseUrl = 'https://debug.dhis2.org/dev',
+    // dhisConfig.baseUrl = 'https://debug.dhis2.org/dev',
     console.log(dhisConfig);
 } catch (e) {
     // Failed to load config file - use default config


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-17210
Fixes https://dhis2.atlassian.net/browse/BETA-153
Enables the app to handle the new "sharing"-structure. Note that this will still use the "old" sharing-dialog, that does not use the JSON-patch method of updating sharing. 
The most important to fix is the references in models to the old structure - import APIs will still work. 

Sorry for the prettier styling fixes...

 * Implemented transformers to convert between old and new structures
     * This is mainly used because the sharing dialog expects the old format, and we do not have control over that code in this app.
 * Updated the "access"-step in Programs to work on `sharing` object instead of old properties. 
 * In `List`: maps `sharing.public` to `publicAccess`
     * Not feasible to update references here, because Datatable and its rendering of `PublicAccess` are not controlled by the app. It's also not trivial to support "nested" paths for controlling that through `valueRenderer`