### PR TITLE
fix(categoryOptionCombo): remove shortName

### DIFF
--- a/src/config/field-config/field-order.js
+++ b/src/config/field-config/field-order.js
@@ -53,6 +53,10 @@ const fieldOrderByName = new Map([
         'endDate',
         'organisationUnits',
     ]],
+    ['categoryOptionCombo', [
+        'name',
+        'code',
+    ]],
     ['categoryCombo', [
         'name',
         'shortName',


### PR DESCRIPTION

`shortName` is not a persisted field for `categoryOptionCombo`, so saving this didn't do anything. `categoryOptionCombo` did not have any entry in `field-order.js`, so I've added this. Previously it just got the rendered fields from the schema. 