### PR TITLE
fix(dataset/workflow): Add catcombos to workflows and make workflows …

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     },
     "developer": {
       "url": "",
-      "name": "Mark Polak"
+      "name": "HISP"
     },
     "activities": {
       "dhis": {

--- a/src/config/field-config/field-order.js
+++ b/src/config/field-config/field-order.js
@@ -493,6 +493,7 @@ const fieldOrderByName = new Map([
         'name',
         'periodType',
         'dataApprovalLevels',
+        'categoryCombo',
     ]],
     ['optionGroup', [
         'name',

--- a/src/config/field-overrides/dataApprovalWorkflow.js
+++ b/src/config/field-overrides/dataApprovalWorkflow.js
@@ -4,4 +4,11 @@ export default new Map([
     ['periodType', {
         component: PeriodTypeDropDown,
     }],
+    ['categoryCombo', {
+        referenceType: 'categoryCombo',
+        fieldOptions: {
+            queryParamFilter: ['dataDimensionType:eq:ATTRIBUTE', 'name:eq:default'],
+            defaultToDefaultValue: true,
+        },
+    }],
 ]);

--- a/src/config/field-rules.js
+++ b/src/config/field-rules.js
@@ -951,10 +951,16 @@ export default new Map([
                 type: 'CHANGE_VALUE',
                 setValue: (model, fieldConfig) => {
                     try {
+                        var filters = ['categoryCombo.id:eq:' + model.dataValues.categoryCombo.id];
+                        if (model.dataValues.categoryCombo.name == 'default') {
+                            // For backwards-compatibility with versions of DHIS2 where workflows
+                            // could have null catcombos
+                            filters.push('categoryCombo.id:null');
+                        }
                         if (!Array.isArray(fieldConfig.props.queryParamFilter)) {
-                            fieldConfig.props.queryParamFilter = ['categoryCombo.id:eq:' + model.dataValues.categoryCombo.id];
-                        } else if (!fieldConfig.props.queryParamFilter.includes('categoryCombo.id:eq:' + model.dataValues.categoryCombo.id)) {
-                            fieldConfig.props.queryParamFilter = ['categoryCombo.id:eq:' + model.dataValues.categoryCombo.id];
+                            fieldConfig.props.queryParamFilter = filters;
+                        } else if (!fieldConfig.props.queryParamFilter.includes(filters[0])) {
+                            fieldConfig.props.queryParamFilter = filters;
                             fieldConfig.value = model[fieldConfig.name] = undefined;
                         }
                     } catch (e) {

--- a/src/config/field-rules.js
+++ b/src/config/field-rules.js
@@ -951,12 +951,7 @@ export default new Map([
                 type: 'CHANGE_VALUE',
                 setValue: (model, fieldConfig) => {
                     try {
-                        var filters = ['categoryCombo.id:eq:' + model.dataValues.categoryCombo.id];
-                        if (model.dataValues.categoryCombo.name == 'default') {
-                            // For backwards-compatibility with versions of DHIS2 where workflows
-                            // could have null catcombos
-                            filters.push('categoryCombo.id:null');
-                        }
+                        var filters = ['categoryCombo.id:eq:' + model.dataValues.categoryCombo.id, 'categoryCombo.id:null'];
                         if (!Array.isArray(fieldConfig.props.queryParamFilter)) {
                             fieldConfig.props.queryParamFilter = filters;
                         } else if (!fieldConfig.props.queryParamFilter.includes(filters[0])) {

--- a/src/config/field-rules.js
+++ b/src/config/field-rules.js
@@ -942,41 +942,6 @@ export default new Map([
             }]
         },
         {
-            field: 'categoryCombo',
-            when: {
-                field: 'workflow',
-                operator: 'HAS_VALUE',
-            },
-            operations: [{
-                field: 'categoryCombo',
-                type: 'SET_PROP',
-                propName: 'disabled',
-                thenValue: true,
-                elseValue: false,
-            },
-            {
-                field: 'categoryCombo',
-                type: 'SET_PROP',
-                propName: 'labelText',
-                thenValue: 'Category combination (*) (to change, set Data approval workflow to <No value>)',
-                elseValue: 'Category combination (*)',
-            }]
-        },
-        {
-            field: 'workflow',
-            when: {
-                field: 'workflow',
-                operator: 'HAS_VALUE',
-            },
-            operations: [{
-                field: 'workflow',
-                type: 'SET_PROP',
-                propName: 'labelText',
-                thenValue: 'Data approval workflow (to change Category combination, set this to <No value>)',
-                elseValue: 'Data approval workflow',
-            }]
-        },
-        {
             field: 'workflow',
             when: [{
                 field: 'categoryCombo',
@@ -986,7 +951,12 @@ export default new Map([
                 type: 'CHANGE_VALUE',
                 setValue: (model, fieldConfig) => {
                     try {
-                        fieldConfig.props.queryParamFilter = ['categoryCombo.id:eq:' + model.dataValues.categoryCombo.id];
+                        if (!Array.isArray(fieldConfig.props.queryParamFilter)) {
+                            fieldConfig.props.queryParamFilter = ['categoryCombo.id:eq:' + model.dataValues.categoryCombo.id];
+                        } else if (!fieldConfig.props.queryParamFilter.includes('categoryCombo.id:eq:' + model.dataValues.categoryCombo.id)) {
+                            fieldConfig.props.queryParamFilter = ['categoryCombo.id:eq:' + model.dataValues.categoryCombo.id];
+                            fieldConfig.value = model[fieldConfig.name] = undefined;
+                        }
                     } catch (e) {
                         return;
                     }

--- a/src/config/field-rules.js
+++ b/src/config/field-rules.js
@@ -951,7 +951,7 @@ export default new Map([
                 type: 'CHANGE_VALUE',
                 setValue: (model, fieldConfig) => {
                     try {
-                        var filters = ['categoryCombo.id:eq:' + model.dataValues.categoryCombo.id, 'categoryCombo.id:null'];
+                        const filters = ['categoryCombo.id:eq:' + model.dataValues.categoryCombo.id, 'categoryCombo.id:null'];
                         if (!Array.isArray(fieldConfig.props.queryParamFilter)) {
                             fieldConfig.props.queryParamFilter = filters;
                         } else if (!fieldConfig.props.queryParamFilter.includes(filters[0])) {

--- a/src/config/field-rules.js
+++ b/src/config/field-rules.js
@@ -953,6 +953,13 @@ export default new Map([
                 propName: 'disabled',
                 thenValue: true,
                 elseValue: false,
+            },
+            {
+                field: 'categoryCombo',
+                type: 'SET_PROP',
+                propName: 'labelText',
+                thenValue: 'Category combination (*) (to change, set Data approval workflow to <No value>)',
+                elseValue: 'Category combination (*)',
             }]
         },
         {

--- a/src/config/field-rules.js
+++ b/src/config/field-rules.js
@@ -942,6 +942,20 @@ export default new Map([
             }]
         },
         {
+            field: 'categoryCombo',
+            when: {
+                field: 'workflow',
+                operator: 'HAS_VALUE',
+            },
+            operations: [{
+                field: 'categoryCombo',
+                type: 'SET_PROP',
+                propName: 'disabled',
+                thenValue: true,
+                elseValue: false,
+            }]
+        },
+        {
             field: 'workflow',
             when: [{
                 field: 'categoryCombo',
@@ -954,21 +968,6 @@ export default new Map([
                         fieldConfig.props.queryParamFilter = ['categoryCombo.id:eq:' + model.dataValues.categoryCombo.id];
                     } catch (e) {
                         return;
-                    }
-                }
-            }],
-        },
-        {
-            field: 'workflow',
-            when: {
-                field: 'categoryCombo',
-                operator: 'CHANGE_VALUE',
-            },
-            operations: [{
-                type: 'CHANGE_VALUE',
-                setValue: (model, fieldConfig) => {
-                    if (fieldConfig) {
-                        fieldConfig.value = model[fieldConfig.name] = {};
                     }
                 }
             }]

--- a/src/config/field-rules.js
+++ b/src/config/field-rules.js
@@ -50,6 +50,17 @@ function setValueTypeToOptionSet(model, fieldConfig) {
     }
 }
 
+/*
+    Updates the Data Approval Workflow to match the Category Combo of the Data Set */
+function alignDataApprovalWorkflow(model, fieldConfig) {
+    try {
+        fieldConfig.props.queryParamFilter = ['categoryCombo.id:eq:' + model.dataValues.categoryCombo.id];
+    } catch (e) {
+        return;
+    }
+}
+
+
 export default new Map([
     ['dataElement', [
         {
@@ -623,7 +634,7 @@ export default new Map([
         },
     ]],
     ['eventProgramStage', [
-        createDefaultRuleForField('validationStrategy', "ON_UPDATE_AND_INSERT"),
+        createDefaultRuleForField('validationStrategy', 'ON_UPDATE_AND_INSERT'),
     ]],
     ['programIndicator', [{
         field: 'orgUnitField',
@@ -887,8 +898,8 @@ export default new Map([
                 }
             }]
         }
-     ]],
-     ['sqlView', [
+    ]],
+    ['sqlView', [
         {
             field: 'name',
             when: {
@@ -940,10 +951,21 @@ export default new Map([
             operations: [{
                 type: 'HIDE_FIELD',
             }]
-        }
+        },
+        {
+            field: 'workflow',
+            when: [{
+                field: 'categoryCombo',
+                operator: 'HAS_VALUE',
+            }],
+            operations: [{
+                type: 'CHANGE_VALUE',
+                setValue: alignDataApprovalWorkflow,
+            }],
+        },
     ]],
     ['predictor', [
-        createDefaultRuleForField('organisationUnitDescendants', "SELECTED"),
+        createDefaultRuleForField('organisationUnitDescendants', 'SELECTED'),
     ]],
     ['eventProgram', [
         {

--- a/src/config/field-rules.js
+++ b/src/config/field-rules.js
@@ -50,17 +50,6 @@ function setValueTypeToOptionSet(model, fieldConfig) {
     }
 }
 
-/*
-    Updates the Data Approval Workflow to match the Category Combo of the Data Set */
-function alignDataApprovalWorkflow(model, fieldConfig) {
-    try {
-        fieldConfig.props.queryParamFilter = ['categoryCombo.id:eq:' + model.dataValues.categoryCombo.id];
-    } catch (e) {
-        return;
-    }
-}
-
-
 export default new Map([
     ['dataElement', [
         {
@@ -960,8 +949,29 @@ export default new Map([
             }],
             operations: [{
                 type: 'CHANGE_VALUE',
-                setValue: alignDataApprovalWorkflow,
+                setValue: (model, fieldConfig) => {
+                    try {
+                        fieldConfig.props.queryParamFilter = ['categoryCombo.id:eq:' + model.dataValues.categoryCombo.id];
+                    } catch (e) {
+                        return;
+                    }
+                }
             }],
+        },
+        {
+            field: 'workflow',
+            when: {
+                field: 'categoryCombo',
+                operator: 'CHANGE_VALUE',
+            },
+            operations: [{
+                type: 'CHANGE_VALUE',
+                setValue: (model, fieldConfig) => {
+                    if (fieldConfig) {
+                        fieldConfig.value = model[fieldConfig.name] = {};
+                    }
+                }
+            }]
         },
     ]],
     ['predictor', [

--- a/src/config/field-rules.js
+++ b/src/config/field-rules.js
@@ -957,6 +957,20 @@ export default new Map([
         },
         {
             field: 'workflow',
+            when: {
+                field: 'workflow',
+                operator: 'HAS_VALUE',
+            },
+            operations: [{
+                field: 'workflow',
+                type: 'SET_PROP',
+                propName: 'labelText',
+                thenValue: 'Data approval workflow (to change Category combination, set this to <No value>)',
+                elseValue: 'Data approval workflow',
+            }]
+        },
+        {
+            field: 'workflow',
             when: [{
                 field: 'categoryCombo',
                 operator: 'HAS_VALUE',


### PR DESCRIPTION
The full title was "fix(dataset/workflow): Add catcombos to workflows and make workflows only selectable when their catcombo matches the data set's" but it looks like that was too long.

This code implements all four requests from [DHIS2-17576](https://dhis2.atlassian.net/browse/DHIS2-17576).

[DHIS2-17576]: https://dhis2.atlassian.net/browse/DHIS2-17576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ