### PR TITLE
fix(sqlview): When current user in SQL view, do not cache

### DIFF
--- a/src/config/field-rules.js
+++ b/src/config/field-rules.js
@@ -915,6 +915,29 @@ export default new Map([
                 elseValue: false,
             }],
         },
+        {
+            field: 'cacheStrategy',
+            when: [{
+                field: 'sqlQuery',
+                operator: 'HAS_VALUE',
+            }],
+            operations: [{
+                type: 'CHANGE_VALUE',
+                setValue: (model, fieldConfig) => {
+                    try {
+                        if (model.dataValues.sqlQuery.includes('${_current_user_id}') ||
+                            model.dataValues.sqlQuery.includes('${_current_username}')) {
+                            fieldConfig.value = model[fieldConfig.name] = 'NO_CACHE';
+                            fieldConfig.props.disabled = true;
+                        } else {
+                            fieldConfig.props.disabled = false;
+                        }
+                    } catch (e) {
+                        return;
+                    }
+                }
+            }]
+        },
     ]],
     ['analyticsTableHook', [
         {


### PR DESCRIPTION
This code implements the request from [DHIS2-9300](https://dhis2.atlassian.net/browse/DHIS2-9300), namely that if `${_current_user_id}` or `${_current_username}` is in a SQL view, then the SQL view should not be allowed to cache, as caching would keep the same results in the SQL view if one user were to log in and another user were to log out.

[DHIS2-9300]: https://dhis2.atlassian.net/browse/DHIS2-9300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ