### PR TITLE
fix: improve error-message handling when saving objects

### DIFF
--- a/src/EditModel/form-helpers/extractFirstErrorMessageFromServer.js
+++ b/src/EditModel/form-helpers/extractFirstErrorMessageFromServer.js
@@ -10,6 +10,7 @@ export default function extractFirstErrorMessageFromServer(response) {
     const messages = [
         extractFirstMessageFromErrorReports(response),
         extractFirstMessageFromMessages(response),
+        response.message
     ];
 
     return firstNotUndefinedIn(messages);


### PR DESCRIPTION

Backend errors can have multiple different response-structures. Adds a simple check for `message` in case `errorReports` or nested messages is not available. This should fix many cases of empty snackbars when trying to save due to an error. 