### PR TITLE
chore: remove ArcGIS Feature from map service options in external layer

### DIFF
--- a/src/config/field-overrides/externalMapLayer.js
+++ b/src/config/field-overrides/externalMapLayer.js
@@ -102,4 +102,17 @@ export default new Map([
             },
         },
     ],
+    [
+        'mapService',
+        {
+            required: true,
+            component: props => {
+                const options = props.options.filter(
+                    option => option.value !== 'ARCGIS_FEATURE'
+                );
+
+                return <DropDown {...props} options={options} />;
+            },
+        },
+    ],
 ]);


### PR DESCRIPTION
ArcGIS Feature is not yet supported in the maps app, so we shouldn't yet let users add external layers of this type

Before:
![image](https://github.com/user-attachments/assets/4a8befd0-68a9-41e5-87bd-7e7261f34f72)


After: 
![image](https://github.com/user-attachments/assets/69ed0200-8412-4ef1-bec7-8e7ccf7118c3)
