### PR TITLE
chore: remove ArcGIS Feature from map service options in external layer [v40]

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -55,7 +55,7 @@ jobs:
             - name: Build
               run: yarn build
 
-            - uses: actions/upload-artifact@v2
+            - uses: actions/upload-artifact@v4
               with:
                   name: app-build
                   path: |
@@ -114,7 +114,7 @@ jobs:
               with:
                   node-version: 12.x
 
-            - uses: actions/download-artifact@v2
+            - uses: actions/download-artifact@v4
               with:
                   name: app-build
 

--- a/src/config/field-overrides/externalMapLayer.js
+++ b/src/config/field-overrides/externalMapLayer.js
@@ -95,4 +95,17 @@ export default new Map([
             },
         },
     ],
+    [
+        'mapService',
+        {
+            required: true,
+            component: props => {
+                const options = props.options.filter(
+                    option => option.value !== 'ARCGIS_FEATURE'
+                );
+
+                return <DropDown {...props} options={options} />;
+            },
+        },
+    ],
 ]);


### PR DESCRIPTION
ArcGIS Feature is not yet supported in the maps app, so we shouldn't yet let users add external layers of this type