### PR TITLE
fix: correctly list manifest shortcuts as an array instead of an object

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -30,7 +30,7 @@ jobs:
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
                   path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock', 'patches/**') }}
 
             - name: Install
               if: steps.yarn-cache.outputs.cache-hit != 'true'
@@ -50,7 +50,7 @@ jobs:
               id: yarn-cache
               with:
                   path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock', 'patches/**') }}
 
             - name: Build
               run: yarn build
@@ -77,7 +77,7 @@ jobs:
               id: yarn-cache
               with:
                   path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock', 'patches/**') }}
 
             - name: Lint
               run: yarn lint
@@ -96,7 +96,7 @@ jobs:
               id: yarn-cache
               with:
                   path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock', 'patches/**') }}
 
             - name: Test
               run: yarn test


### PR DESCRIPTION
This issue was caused because package patches were not being applied - the yarn.lock hash wasn't updated, so the cache had a stale copy of the dependencies which should have been patched.  This ended up breaking the dhis2-core build