### PR TITLE
feat(manifest): add shortcuts for command palette [DHIS2-19411] (42.0)

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -30,7 +30,7 @@ jobs:
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
                   path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock', 'patches/**') }}
 
             - name: Install
               if: steps.yarn-cache.outputs.cache-hit != 'true'
@@ -50,7 +50,7 @@ jobs:
               id: yarn-cache
               with:
                   path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock', 'patches/**') }}
 
             - name: Build
               run: yarn build
@@ -77,7 +77,7 @@ jobs:
               id: yarn-cache
               with:
                   path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock', 'patches/**') }}
 
             - name: Lint
               run: yarn lint
@@ -96,7 +96,7 @@ jobs:
               id: yarn-cache
               with:
                   path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock', 'patches/**') }}
 
             - name: Test
               run: yarn test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maintenance-app",
-    "version": "32.34.1",
+    "version": "32.34.1-v42.0",
     "description": "DHIS2 Maintenance app",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,137 +1,327 @@
 {
-  "name": "maintenance-app",
-  "version": "32.34.0",
-  "description": "DHIS2 Maintenance app",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/dhis2/maintenance-app.git"
-  },
-  "license": "BSD-3-Clause",
-  "scripts": {
-    "prestart": "d2-manifest package.json manifest.webapp",
-    "start": "webpack-dev-server",
-    "coverage": "npm test -- --coverage",
-    "test": "jest",
-    "test:watch": "npm test -- --watch",
-    "prebuild": "rm -rf build",
-    "build": "npm test && NODE_ENV=production webpack --progress && npm run manifest",
-    "postbuild": "cp -r src/i18n icon.png package.json ./build/ && yarn copy-ckeditor",
-    "validate": "npm ls --depth 0",
-    "manifest": "d2-manifest package.json build/manifest.webapp",
-    "lint": "eslint ./src",
-    "profile": "npm run start -- --profile",
-    "copy-ckeditor": "mkdir ./build/vendor && cp -r ./node_modules/ckeditor ./build/vendor",
-    "postinstall": "patch-package"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.3",
-    "babel-eslint": "^8.2.3",
-    "babel-jest": "^23.0.1",
-    "babel-loader": "latest",
-    "babel-plugin-dynamic-import-node": "^1.2.0",
-    "babel-plugin-transform-runtime": "^6.12.0",
-    "babel-polyfill": "^6.26.0",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-es2015": "^6.13.2",
-    "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-0": "^6.5.0",
-    "classnames": "^2.2.3",
-    "css-loader": "^0.28.1",
-    "d2-manifest": "^1.0.0-2",
-    "d2-utilizr": "^0.2.9",
-    "d3-color": "^1.0.2",
-    "d3-format": "^1.0.2",
-    "d3-scale": "^1.0.3",
-    "enzyme": "^3.0.0",
-    "enzyme-adapter-react-15": "^1.0.0",
-    "eslint": "^5.0.1",
-    "eslint-config-prettier": "^2.9.0",
-    "eslint-config-react-app": "^2.1.0",
-    "eslint-plugin-flowtype": "^2.49.3",
-    "eslint-plugin-import": "^2.13.0",
-    "eslint-plugin-jsx-a11y": "^5.0.1",
-    "eslint-plugin-react": "^7.10.0",
-    "fbjs": "^0.8.8",
-    "file-loader": "2",
-    "glob": "^7.1.1",
-    "html-webpack-plugin": "^2.26.0",
-    "ignore-styles": "^5.0.1",
-    "jest": "^23.0.1",
-    "jest-enzyme": "^4.0.0",
-    "json-loader": "^0.5.4",
-    "lodash.isfinite": "^3.3.1",
-    "lodash.isnumber": "^3.0.3",
-    "loglevel": "^1.4.0",
-    "moment": "^2.16.0",
-    "node-fetch": "^1.6.3",
-    "node-pre-gyp": "^0.17.0",
-    "node-sass": "npm:sass@^1.58.0",
-    "precommit-hook": "^3.0.0",
-    "prettier": "^1.13.7",
-    "recompose": "^0.23.1",
-    "redux-logger": "^3.0.6",
-    "sass-loader": "^6.0.5",
-    "style-loader": "^0.16.1",
-    "webpack": "^2.5.1",
-    "webpack-bundle-analyzer": "^2.7.0",
-    "webpack-dev-server": "^2.4.5",
-    "webpack-visualizer-plugin": "^0.1.5"
-  },
-  "dependencies": {
-    "@dhis2/d2-ui-header-bar": "^1.1.4",
-    "@dhis2/d2-ui-sharing-dialog": "^1.0.12",
-    "ckeditor": "4.6.1",
-    "d2": "^30.2.3",
-    "d2-ui": "29.0.34",
-    "dompurify": "^3.0.9",
-    "lodash": "^4.17.11",
-    "material-design-icons-iconfont": "^4.0.5",
-    "material-ui": "^0.17.0",
-    "nyc": "10.1.2",
-    "patch-package": "^8.0.0",
-    "postinstall-postinstall": "^2.1.0",
-    "prop-types": "^15.6.0",
-    "react": "~15.5.0",
-    "react-addons-create-fragment": "^15.5.4",
-    "react-addons-css-transition-group": "^15.3.1",
-    "react-addons-linked-state-mixin": "^15.3.1",
-    "react-addons-perf": "^15.3.1",
-    "react-addons-shallow-compare": "^15.3.1",
-    "react-addons-test-utils": "^15.3.1",
-    "react-color": "^2.11.7",
-    "react-dnd": "^2.4.0",
-    "react-dnd-html5-backend": "^2.4.1",
-    "react-dom": "~15.5.0",
-    "react-loadable": "5.3",
-    "react-redux": "^5.0.3",
-    "react-router": "^3.0.0",
-    "react-sortable-hoc": "^0.6.1",
-    "react-speed-dial": "^0.4.7",
-    "react-tap-event-plugin": "2.0.1",
-    "react-test-renderer": "15",
-    "redux": "^3.6.0",
-    "redux-observable": "0.18.0",
-    "rxjs": "^5.2.0",
-    "typeface-roboto": "^0.0.54"
-  },
-  "pre-commit": [
-    "test"
-  ],
-  "manifest.webapp": {
-    "short_name": "maintenance",
-    "name": "Maintenance app",
-    "icons": {
-      "48": "icon.png"
+    "name": "maintenance-app",
+    "version": "32.34.1",
+    "description": "DHIS2 Maintenance app",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dhis2/maintenance-app.git"
     },
-    "developer": {
-      "url": "",
-      "name": "DHIS2"
+    "license": "BSD-3-Clause",
+    "scripts": {
+        "prestart": "d2-manifest package.json manifest.webapp",
+        "start": "webpack-dev-server",
+        "coverage": "npm test -- --coverage",
+        "test": "jest",
+        "test:watch": "npm test -- --watch",
+        "prebuild": "rm -rf build",
+        "build": "npm test && NODE_ENV=production webpack --progress && npm run manifest",
+        "postbuild": "cp -r src/i18n icon.png package.json ./build/ && yarn copy-ckeditor",
+        "validate": "npm ls --depth 0",
+        "manifest": "d2-manifest package.json build/manifest.webapp",
+        "lint": "eslint ./src",
+        "profile": "npm run start -- --profile",
+        "copy-ckeditor": "mkdir ./build/vendor && cp -r ./node_modules/ckeditor ./build/vendor",
+        "postinstall": "patch-package"
     },
-    "activities": {
-      "dhis": {
-        "href": ".."
-      }
+    "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.3",
+        "babel-eslint": "^8.2.3",
+        "babel-jest": "^23.0.1",
+        "babel-loader": "latest",
+        "babel-plugin-dynamic-import-node": "^1.2.0",
+        "babel-plugin-transform-runtime": "^6.12.0",
+        "babel-polyfill": "^6.26.0",
+        "babel-preset-env": "^1.7.0",
+        "babel-preset-es2015": "^6.13.2",
+        "babel-preset-react": "^6.24.1",
+        "babel-preset-stage-0": "^6.5.0",
+        "classnames": "^2.2.3",
+        "css-loader": "^0.28.1",
+        "d2-manifest": "^1.0.0-2",
+        "d2-utilizr": "^0.2.9",
+        "d3-color": "^1.0.2",
+        "d3-format": "^1.0.2",
+        "d3-scale": "^1.0.3",
+        "enzyme": "^3.0.0",
+        "enzyme-adapter-react-15": "^1.0.0",
+        "eslint": "^5.0.1",
+        "eslint-config-prettier": "^2.9.0",
+        "eslint-config-react-app": "^2.1.0",
+        "eslint-plugin-flowtype": "^2.49.3",
+        "eslint-plugin-import": "^2.13.0",
+        "eslint-plugin-jsx-a11y": "^5.0.1",
+        "eslint-plugin-react": "^7.10.0",
+        "fbjs": "^0.8.8",
+        "file-loader": "2",
+        "glob": "^7.1.1",
+        "html-webpack-plugin": "^2.26.0",
+        "ignore-styles": "^5.0.1",
+        "jest": "^23.0.1",
+        "jest-enzyme": "^4.0.0",
+        "json-loader": "^0.5.4",
+        "lodash.isfinite": "^3.3.1",
+        "lodash.isnumber": "^3.0.3",
+        "loglevel": "^1.4.0",
+        "moment": "^2.16.0",
+        "node-fetch": "^1.6.3",
+        "node-pre-gyp": "^0.17.0",
+        "node-sass": "npm:sass@^1.58.0",
+        "precommit-hook": "^3.0.0",
+        "prettier": "^1.13.7",
+        "recompose": "^0.23.1",
+        "redux-logger": "^3.0.6",
+        "sass-loader": "^6.0.5",
+        "style-loader": "^0.16.1",
+        "webpack": "^2.5.1",
+        "webpack-bundle-analyzer": "^2.7.0",
+        "webpack-dev-server": "^2.4.5",
+        "webpack-visualizer-plugin": "^0.1.5"
+    },
+    "dependencies": {
+        "@dhis2/d2-ui-header-bar": "^1.1.4",
+        "@dhis2/d2-ui-sharing-dialog": "^1.0.12",
+        "ckeditor": "4.6.1",
+        "d2": "^30.2.3",
+        "d2-ui": "29.0.34",
+        "dompurify": "^3.0.9",
+        "lodash": "^4.17.11",
+        "material-design-icons-iconfont": "^4.0.5",
+        "material-ui": "^0.17.0",
+        "nyc": "10.1.2",
+        "patch-package": "^8.0.0",
+        "postinstall-postinstall": "^2.1.0",
+        "prop-types": "^15.6.0",
+        "react": "~15.5.0",
+        "react-addons-create-fragment": "^15.5.4",
+        "react-addons-css-transition-group": "^15.3.1",
+        "react-addons-linked-state-mixin": "^15.3.1",
+        "react-addons-perf": "^15.3.1",
+        "react-addons-shallow-compare": "^15.3.1",
+        "react-addons-test-utils": "^15.3.1",
+        "react-color": "^2.11.7",
+        "react-dnd": "^2.4.0",
+        "react-dnd-html5-backend": "^2.4.1",
+        "react-dom": "~15.5.0",
+        "react-loadable": "5.3",
+        "react-redux": "^5.0.3",
+        "react-router": "^3.0.0",
+        "react-sortable-hoc": "^0.6.1",
+        "react-speed-dial": "^0.4.7",
+        "react-tap-event-plugin": "2.0.1",
+        "react-test-renderer": "15",
+        "redux": "^3.6.0",
+        "redux-observable": "0.18.0",
+        "rxjs": "^5.2.0",
+        "typeface-roboto": "^0.0.54"
+    },
+    "pre-commit": [
+        "test"
+    ],
+    "manifest.webapp": {
+        "short_name": "maintenance",
+        "name": "Maintenance app",
+        "icons": {
+            "48": "icon.png"
+        },
+        "developer": {
+            "url": "",
+            "name": "DHIS2"
+        },
+        "activities": {
+            "dhis": {
+                "href": ".."
+            }
+        },
+        "shortcuts": [
+            {
+                "name": "Categories",
+                "url": "#/list/categorySection/category"
+            },
+            {
+                "name": "Category options",
+                "url": "#/list/categorySection/categoryOption"
+            },
+            {
+                "name": "Category combinations",
+                "url": "#/list/categorySection/categoryCombo"
+            },
+            {
+                "name": "Category option combinations",
+                "url": "#/list/categorySection/categoryOptionCombo"
+            },
+            {
+                "name": "Category option groups",
+                "url": "#/list/categorySection/categoryOptionGroup"
+            },
+            {
+                "name": "Category option group sets",
+                "url": "#/list/categorySection/categoryOptionGroupSet"
+            },
+            {
+                "name": "Data elements",
+                "url": "#/list/dataElementSection/dataElement"
+            },
+            {
+                "name": "Data element groups ",
+                "url": "#/list/dataElementSection/dataElementGroup"
+            },
+            {
+                "name": "Data element group sets",
+                "url": "#/list/dataElementSection/dataElementGroupSet"
+            },
+            {
+                "name": "Data sets",
+                "url": "#/list/dataSetSection/dataSet"
+            },
+            {
+                "name": "Data set notifications",
+                "url": "#/list/dataSetSection/dataSetNotificationTemplate"
+            },
+            {
+                "name": "Indicators",
+                "url": "#/list/indicatorSection/indicator"
+            },
+            {
+                "name": "Indicator types",
+                "url": "#/list/indicatorSection/indicatorType"
+            },
+            {
+                "name": "Indicator groups",
+                "url": "#/list/indicatorSection/indicatorGroup"
+            },
+            {
+                "name": "Indicator group sets",
+                "url": "#/list/indicatorSection/indicatorGroupSet"
+            },
+            {
+                "name": "Program indicators",
+                "url": "#/list/indicatorSection/programIndicator"
+            },
+            {
+                "name": "Program indicator groups",
+                "url": "#/list/indicatorSection/programIndicatorGroup"
+            },
+            {
+                "name": "Organisation units",
+                "url": "#/list/organisationUnitSection/organisationUnit"
+            },
+            {
+                "name": "Organisaiton unit groups",
+                "url": "#/list/organisationUnitSection/organisationUnitGroup"
+            },
+            {
+                "name": "Organisation unit group sets",
+                "url": "#/list/organisationUnitSection/organisationUnitGroupSet"
+            },
+            {
+                "name": "Organisation unit levels",
+                "url": "#/list/organisationUnitSection/organisationUnitLevel"
+            },
+            {
+                "name": "Hierarchy operations",
+                "url": "#/organisationUnitSection/hierarchy"
+            },
+            {
+                "name": "Programs",
+                "url": "#/list/programSection/program"
+            },
+            {
+                "name": "Tracked entity attributes",
+                "url": "#/list/programSection/trackedEntityAttribute"
+            },
+            {
+                "name": "Relationship types",
+                "url": "#/list/programSection/relationshipType"
+            },
+            {
+                "name": "Tracked entity types",
+                "url": "#/list/programSection/trackedEntityType"
+            },
+            {
+                "name": "Program rules",
+                "url": "#/list/programSection/programRule"
+            },
+            {
+                "name": "Program rule variables",
+                "url": "#/list/programSection/programRuleVariable"
+            },
+            {
+                "name": "Validation rules",
+                "url": "#/list/validationSection/validationRule"
+            },
+            {
+                "name": "Validation rule groups",
+                "url": "#/list/validationSection/validationRuleGroup"
+            },
+            {
+                "name": "Validation notifications",
+                "url": "#/list/validationSection/validationNotificationTemplate"
+            },
+            {
+                "name": "Constants",
+                "url": "#/list/otherSection/constant"
+            },
+            {
+                "name": "Attributes",
+                "url": "#/list/otherSection/attribute"
+            },
+            {
+                "name": "Option sets",
+                "url": "#/list/otherSection/optionSet"
+            },
+            {
+                "name": "Option groups",
+                "url": "#/list/otherSection/optionGroup"
+            },
+            {
+                "name": "Option group sets",
+                "url": "#/list/otherSection/optionGroupSet"
+            },
+            {
+                "name": "Legends",
+                "url": "#/list/otherSection/legendSet"
+            },
+            {
+                "name": "Predictors",
+                "url": "#/list/otherSection/predictor"
+            },
+            {
+                "name": "Predictor groups",
+                "url": "#/list/otherSection/predictorGroup"
+            },
+            {
+                "name": "Push analysis",
+                "url": "#/list/otherSection/pushAnalysis"
+            },
+            {
+                "name": "External map layers",
+                "url": "#/list/otherSection/externalMapLayer"
+            },
+            {
+                "name": "Data approval levels",
+                "url": "#/list/otherSection/dataApprovalLevel"
+            },
+            {
+                "name": "Data approval workflows",
+                "url": "#/list/otherSection/dataApprovalWorkflow"
+            },
+            {
+                "name": "Locales",
+                "url": "#/list/otherSection/locale"
+            },
+            {
+                "name": "SQL views",
+                "url": "#/list/otherSection/sqlView"
+            },
+            {
+                "name": "Icons",
+                "url": "#/list/otherSection/icon"
+            },
+            {
+                "name": "Analytics table hooks",
+                "url": "#/list/otherSection/analyticsTableHook"
+            }
+        ]
     }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
                 "url": "#/list/organisationUnitSection/organisationUnit"
             },
             {
-                "name": "Organisaiton unit groups",
+                "name": "Organisation unit groups",
                 "url": "#/list/organisationUnitSection/organisationUnitGroup"
             },
             {

--- a/patches/d2-manifest+1.0.0.patch
+++ b/patches/d2-manifest+1.0.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/d2-manifest/src/Manifest.js b/node_modules/d2-manifest/src/Manifest.js
+index fedb75f..d0179a9 100644
+--- a/node_modules/d2-manifest/src/Manifest.js
++++ b/node_modules/d2-manifest/src/Manifest.js
+@@ -61,7 +61,7 @@ class Manifest {
+     merge(data, force) {
+         if (data instanceof Object) {
+             Object.keys(data).map(key => {
+-                if (data[key] instanceof Object) {
++                if (data[key] instanceof Object && !Array.isArray(data[key])) {
+                     if (key === 'developer' && data[key].name) {
+                         Object.assign(data[key], Manifest.parseAuthor(data[key].name));
+                     }


### PR DESCRIPTION
Backport of #3067 and #3069 

Approved by RCB

Question - since this is one of very few apps which still use a branching/backporting strategy, we need to choose a version number that makes sense here.... there is exactly one change on master that's not one this branch (https://github.com/dhis2/maintenance-app/pull/3059 @flaminic) which means that the version number on this branch is no longer correct.  Maybe we should post-fix it with `-42.0` or something so that the app version is unique at least, if not semantically correct?

ALTERNATIVE: instead of backporting here, we could just approve the very small change referenced above and then point to the latest built version tag on master from the dhis2-core apps-to-bundle.json (cc @Philip-Larsen-Donnelly)