### PR TITLE
fix: organisation unit group shortcut typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
                 "url": "#/list/organisationUnitSection/organisationUnit"
             },
             {
-                "name": "Organisaiton unit groups",
+                "name": "Organisation unit groups",
                 "url": "#/list/organisationUnitSection/organisationUnitGroup"
             },
             {


### PR DESCRIPTION
Fixes typo reported [here](https://dhis2.atlassian.net/browse/DHIS2-19411?focusedCommentId=212516)